### PR TITLE
chore:#54 불필요한 주석 정리 및 useEffect문 수정

### DIFF
--- a/src/components/_my-page/my-page-edit-profile.tsx
+++ b/src/components/_my-page/my-page-edit-profile.tsx
@@ -15,11 +15,6 @@ import FormSchema from '@/constants/form-schema.constant';
 import { UserDTO } from '@/types/DTO/user.dto';
 import { cleanupBlobUrl } from '@/lib/utils/cleanup-blob-url.util';
 
-/**
- * 사용자 프로필 수정 폼을 위한 유효성 검증 스키마
- * - nickname: 닉네임 유효성 검증 스키마 (2~8자 한글/영문/숫자)
- * - newProfileImage: 새 프로필 이미지 파일 (선택 사항)
- */
 const formSchema = z.object({
   nickname: FormSchema.NICKNAME_SCHEMA,
   newProfileImage: FormSchema.IMAGE_FILE_SCHEMA.nullable()
@@ -27,34 +22,13 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>;
 
-/**
- * 마이페이지 프로필 수정 컴포넌트
- * 사용자가 자신의 프로필 정보(닉네임, 프로필 이미지)를 수정할 수 있는 폼을 제공합니다.
- *
- * @param {Object} props - 컴포넌트 속성
- * @param {UserDTO} props.userInfo - 현재 사용자 정보
- * @returns {JSX.Element} 프로필 수정 폼 UI
- */
 const MyPageEditProfile = ({ userInfo }: { userInfo: UserDTO }): JSX.Element => {
-  /**
-   * 프로필 상태 관리
-   * - isUploading: 업로드 진행 중 상태를 나타냄
-   * - profilePreviewUrl: 프로필 이미지 미리보기 URL
-   */
   const [profileState, setProfileState] = useState({
     isUploading: false,
     profilePreviewUrl: userInfo?.profileImage || null
   });
-
-  /**
-   * 파일 입력 요소에 접근하기 위한 ref
-   * 프로필 이미지 클릭 시 파일 선택 다이얼로그를 표시하는 데 사용
-   */
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  /**
-   * 프로필 수정 폼 초기화 및 유효성 검증 설정
-   */
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -63,31 +37,17 @@ const MyPageEditProfile = ({ userInfo }: { userInfo: UserDTO }): JSX.Element => 
     }
   });
 
-  /**
-   * 컴포넌트 언마운트 시 Blob URL 정리를 위한 효과
-   * 메모리 누수 방지를 위해 생성된 객체 URL 해제
-   */
   useEffect(() => {
+    // profilePreviewUrl 변경 또는 언마운트 시 Blob URL 정리 → 메모리 누수 방지
     return () => {
       cleanupBlobUrl(profileState.profilePreviewUrl);
     };
-  }, []);
+  }, [profileState.profilePreviewUrl]);
 
-  /**
-   * 프로필 이미지 변경 처리 핸들러
-   * 사용자가 새 이미지를 선택하면:
-   * 1. 기존 Blob URL 정리
-   * 2. 새 이미지의 미리보기 URL 생성
-   * 3. 프로필 상태 및 폼 값 업데이트
-   *
-   * @param {React.ChangeEvent<HTMLInputElement>} e - 파일 입력 변경 이벤트
-   */
   const handleProfileImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
 
     if (!file) return;
-
-    cleanupBlobUrl(profileState.profilePreviewUrl);
 
     const previewUrl = URL.createObjectURL(file);
     setProfileState((prev) => ({
@@ -98,23 +58,11 @@ const MyPageEditProfile = ({ userInfo }: { userInfo: UserDTO }): JSX.Element => 
     form.setValue('newProfileImage', file);
   };
 
-  /**
-   * 프로필 변경 사항 제출 처리 핸들러
-   * 폼 제출 시 사용자 프로필 변경 사항을 처리하는 메인 함수
-   *
-   * 1. 새 이미지 파일 존재 여부 확인
-   * 2. 새 이미지가 있는 경우에만 업로드 처리
-   * 3. 변경 사항 확인 (닉네임 또는 이미지 변경 여부)
-   * 4. 사용자 정보 업데이트
-   * 5. 성공 처리
-   *
-   * @param {FormValues} formData - 폼 제출 데이터 (닉네임, 새 프로필 이미지)
-   */
   const handleSubmitProfileChanges = async (formData: FormValues): Promise<void> => {
     setIsUploading(true);
 
     const newProfileImageFile = form.getValues('newProfileImage');
-    let imageUrl = profileState.profilePreviewUrl; // 프로필 UI에 노출되고 있는 이미지
+    let imageUrl = profileState.profilePreviewUrl;
 
     if (newProfileImageFile) {
       const uploadResult = await handleProfileImageUpload(newProfileImageFile);
@@ -125,7 +73,6 @@ const MyPageEditProfile = ({ userInfo }: { userInfo: UserDTO }): JSX.Element => 
       imageUrl = uploadResult;
     }
 
-    // 변경 사항이 없는 경우 (닉네임과 이미지 모두 동일)
     if (formData.nickname === userInfo.nickname && imageUrl === userInfo.profileImage) {
       alert('변경된 정보가 없습니다.');
       setIsUploading(false);
@@ -141,27 +88,10 @@ const MyPageEditProfile = ({ userInfo }: { userInfo: UserDTO }): JSX.Element => 
     setIsUploading(false);
   };
 
-  /**
-   * 업로드 상태 설정 헬퍼 함수
-   * 프로필 이미지 업로드 중임을 표시하는 상태를 관리
-   *
-   * @param {boolean} isUploading - 업로드 진행 상태
-   */
   const setIsUploading = (isUploading: boolean): void => {
     setProfileState((prev) => ({ ...prev, isUploading }));
   };
 
-  /**
-   * 프로필 이미지 스토리지 업로드 처리 함수
-   * 이미지 파일을 Supabase 스토리지에 업로드하고 결과 URL을 반환합니다.
-   *
-   * 1. 이미지 업로드를 위한 FormData 생성
-   * 2. 이미지 업로드 API 호출
-   * 3. 업로드 결과 처리 및 URL 반환
-   *
-   * @param {File} imageFile - 업로드할 이미지 파일
-   * @returns {Promise<string | null>} 업로드된 이미지 URL 또는 에러 시 null
-   */
   const handleProfileImageUpload = async (imageFile: File): Promise<string | null> => {
     const uploadForm = new FormData();
     uploadForm.append('file', imageFile);
@@ -171,19 +101,12 @@ const MyPageEditProfile = ({ userInfo }: { userInfo: UserDTO }): JSX.Element => 
     if (result.error) {
       alert(`${result.error.message} ${result.error.action}`);
       setIsUploading(false);
-      return null; // 업로드 실패
+      return null;
     }
 
-    return result.data; // 새 이미지 URL 반환
+    return result.data;
   };
 
-  /**
-   * 프로필 업데이트 성공 처리 함수
-   * 성공 메시지 표시 및 폼/상태 초기화
-   *
-   * @param {string} nickname - 업데이트된 닉네임
-   * @param {string | null} newImageUrl - 업데이트된 이미지 URL
-   */
   const handleProfileUpdateSuccess = (nickname: string, newImageUrl: string | null) => {
     form.reset({ nickname, newProfileImage: null });
     alert('프로필 수정이 완료되었습니다.');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #54

<br>

## 📝 작업 내용

- 불필요한 주석 정리
- `useEffect`문에 의존성 배열을 추가하고 `handleProfileImageChange` 내에 있던 클린업 함수 삭제

<br>

## 💬 리뷰 요구사항

> - 리뷰 예상 시간 : `2분`
> - 주석은 재상 튜터님과 함께 확인하며 불필요한 내용을 모두 삭제했습니다 ! `useEffect` 구문은 한 눈에 코드의 목적을 파악하기 어려울 수 있으므로 남겨두는 게 좋을 것 같다고 피드백 해주셔서 이 내용만 남겨두었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 프로필 편집 관련 내부 로직을 정리하여 코드의 안정성과 효율성을 향상시켰습니다.
- **버그 수정**
	- 프로필 이미지 미리보기 처리 시 메모리 관리가 개선되어 전반적인 성능이 보완되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->