### PR TITLE
Feature/#93 link component

### DIFF
--- a/src/components/commons/button-link.tsx
+++ b/src/components/commons/button-link.tsx
@@ -10,12 +10,35 @@ const buttonLinkVariants = cva(
   {
     variants: {
       variant: {
-        primary:
-          'rounded-[3.125rem] px-6 bg-gray-900 text-gray-50 hover:bg-gray-800 disabled:text-gray-500 disabled:bg-opacity-5',
+        primary: 'rounded-[3.125rem] px-6 bg-gray-900 text-gray-50 hover:bg-gray-800',
         secondary:
-          'rounded-[3.125rem] px-6 bg-white border border-solid border-gray-350/40 hover:border-purple-10 hover:bg-button-gradient disabled:border-gray-200 disabled:bg-white disabled:text-gray-500',
-        ghost: 'rounded-[3.125rem] px-6 text-gray-600 hover:text-gray-800 disabled:text-gray-400',
-        icon: 'text-gray-600 hover:text-gray-800 disabled:text-gray-400 after:bg-no-repeat after:bg-center after:bg-right-line-gray-600-icon hover:after:bg-right-line-gray-800-icon disabled:after:bg-right-line-gray-400-icon'
+          'rounded-[3.125rem] px-6 text-gray-900 bg-white border border-solid border-gray-350/40 hover:border-purple-10 hover:bg-button-gradient',
+        ghost: 'rounded-[3.125rem] px-6 text-gray-600 hover:text-gray-800 ',
+        icon: 'text-gray-600 hover:text-gray-800 after:bg-no-repeat after:bg-center after:bg-right-line-gray-600-icon hover:after:bg-right-line-gray-800-icon'
+      },
+      size: {
+        default: 'h-11 typography-subTitle4 ',
+        sm: 'h-10 typography-subTitle4 gap-[0.125rem] after:w-4 after:h-4',
+        lg: 'h-11 typography-subTitle2 gap-1 after:w-[1.125rem] after:h-[1.125rem]',
+        icon: 'h-9 w-9'
+      }
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'default'
+    }
+  }
+);
+
+const buttonLinkDisabledVariants = cva(
+  'py-[0.625rem] inline-flex items-center justify-center gap-1 whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+  {
+    variants: {
+      variant: {
+        primary: 'rounded-[3.125rem] px-6 bg-gray-900/5 text-gray-500',
+        secondary: 'rounded-[3.125rem] px-6 bg-white border border-solid border-gray-200 text-gray-500',
+        ghost: 'rounded-[3.125rem] px-6 text-gray-400',
+        icon: 'text-gray-400 after:bg-no-repeat after:bg-center after:bg-right-line-gray-400-icon'
       },
       size: {
         default: 'h-11 typography-subTitle4 ',
@@ -46,7 +69,7 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
     if (disabled) {
       return (
         <span
-          className={cn(buttonLinkVariants({ variant, size, className }))}
+          className={cn(buttonLinkDisabledVariants({ variant, size, className }))}
           ref={ref as React.Ref<HTMLSpanElement>}
           {...props}
         >

--- a/src/components/commons/button-link.tsx
+++ b/src/components/commons/button-link.tsx
@@ -54,15 +54,14 @@ const buttonLinkDisabledVariants = cva(
   }
 );
 
-export interface ButtonLinkProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
-    VariantProps<typeof buttonLinkVariants> {
-  href: string;
-  disabled?: boolean;
-  prefetch?: boolean;
-  children: React.ReactNode;
-  className?: string;
-}
+export type ButtonLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  VariantProps<typeof buttonLinkVariants> & {
+    href: string;
+    disabled?: boolean;
+    prefetch?: boolean;
+    children: React.ReactNode;
+    className?: string;
+  };
 
 const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
   ({ className, variant, size, href, disabled = false, prefetch, children, ...props }, ref) => {
@@ -93,5 +92,4 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 );
 
 ButtonLink.displayName = 'ButtonLink';
-
-export { ButtonLink, buttonLinkVariants };
+export default ButtonLink;

--- a/src/components/commons/button-link.tsx
+++ b/src/components/commons/button-link.tsx
@@ -31,7 +31,7 @@ const buttonLinkVariants = cva(
 );
 
 const buttonLinkDisabledVariants = cva(
-  'py-[0.625rem] inline-flex items-center justify-center gap-1 whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+  'py-[0.625rem] inline-flex items-center justify-center gap-1 whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-not-allowed',
   {
     variants: {
       variant: {

--- a/src/components/commons/button-link.tsx
+++ b/src/components/commons/button-link.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import Link from 'next/link';
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+const buttonLinkVariants = cva(
+  'py-[0.625rem] inline-flex items-center justify-center gap-1 whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        primary:
+          'rounded-[3.125rem] px-6 bg-gray-900 text-gray-50 hover:bg-gray-800 disabled:text-gray-500 disabled:bg-opacity-5',
+        secondary:
+          'rounded-[3.125rem] px-6 bg-white border border-solid border-gray-350/40 hover:border-purple-10 hover:bg-button-gradient disabled:border-gray-200 disabled:bg-white disabled:text-gray-500',
+        ghost: 'rounded-[3.125rem] px-6 text-gray-600 hover:text-gray-800 disabled:text-gray-400',
+        icon: 'text-gray-600 hover:text-gray-800 disabled:text-gray-400 after:bg-no-repeat after:bg-center after:bg-right-line-gray-600-icon hover:after:bg-right-line-gray-800-icon disabled:after:bg-right-line-gray-400-icon'
+      },
+      size: {
+        default: 'h-11 typography-subTitle4 ',
+        sm: 'h-10 typography-subTitle4 gap-[0.125rem] after:w-4 after:h-4',
+        lg: 'h-11 typography-subTitle2 gap-1 after:w-[1.125rem] after:h-[1.125rem]',
+        icon: 'h-9 w-9'
+      }
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonLinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    VariantProps<typeof buttonLinkVariants> {
+  href: string;
+  disabled?: boolean;
+  prefetch?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  ({ className, variant, size, href, disabled = false, prefetch, children, ...props }, ref) => {
+    if (disabled) {
+      return (
+        <span
+          className={cn(buttonLinkVariants({ variant, size, className }))}
+          ref={ref as React.Ref<HTMLSpanElement>}
+          {...props}
+        >
+          {children}
+        </span>
+      );
+    }
+
+    return (
+      <Link
+        className={cn(buttonLinkVariants({ variant, size, className }))}
+        ref={ref}
+        href={href}
+        prefetch={prefetch}
+        {...props}
+      >
+        {children}
+      </Link>
+    );
+  }
+);
+
+ButtonLink.displayName = 'ButtonLink';
+
+export { ButtonLink, buttonLinkVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         primary:
           'rounded-[3.125rem] px-6 bg-gray-900 text-gray-50 hover:bg-gray-800 disabled:text-gray-500 disabled:bg-opacity-5',
         secondary:
-          'rounded-[3.125rem] px-6 bg-white border border-solid border-gray-350/40 hover:border-purple-10 hover:bg-button-gradient disabled:border-gray-200 disabled:bg-white disabled:text-gray-500',
+          'rounded-[3.125rem] px-6 bg-white border border-solid border-gray-350/40 text-gray-900 hover:border-purple-10 hover:bg-button-gradient disabled:border-gray-200 disabled:bg-white disabled:text-gray-500',
         ghost: 'rounded-[3.125rem] px-6 text-gray-600 hover:text-gray-800 disabled:text-gray-400',
         icon: 'text-gray-600 hover:text-gray-800 disabled:text-gray-400 after:bg-no-repeat after:bg-center after:bg-right-line-gray-600-icon hover:after:bg-right-line-gray-800-icon disabled:after:bg-right-line-gray-400-icon'
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
-const buttonVariants = cva(
+export const buttonVariants = cva(
   'py-[0.625rem] inline-flex items-center justify-center gap-1 whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none',
   {
     variants: {
@@ -30,18 +30,15 @@ const buttonVariants = cva(
   }
 );
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-}
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
   }
 );
 Button.displayName = 'Button';
-
-export { Button, buttonVariants };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #93

<br>

## 📝 작업 내용

- Button과 동일한 디자인을 가진 Link 컴포넌트 구현했습니다.

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/ecc0862e-8c62-4af2-bd41-77e2a259aea9


<br>

## 💬 리뷰 요구사항
- button의 css 그대로 가져왔습니당~!
- 리뷰 예상 시간: `10분`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 버튼 링크 컴포넌트를 추가하여, 링크를 버튼처럼 활용할 수 있게 됐으며 다양한 스타일(프라이머리, 세컨더리, 고스트, 아이콘)과 크기(기본, 소, 대, 아이콘)를 지원합니다. 비활성화 상태에서는 상호작용이 막히도록 처리되었습니다.
- **스타일**
	- 기존 버튼의 세컨더리 스타일에 어두운 회색 텍스트 색상이 적용되어, 텍스트 가독성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->