### PR TITLE
Feature/#97 icon button

### DIFF
--- a/src/components/commons/icon-button.tsx
+++ b/src/components/commons/icon-button.tsx
@@ -19,7 +19,7 @@ const iconButtonVariants = cva(
   }
 );
 
-const iconImageVariants = cva('object-cover', {
+const iconImageVariants = cva('object-cover shrink-0 ', {
   variants: {
     size: {
       sm: 'w-3 h-3 ',

--- a/src/components/commons/icon-button.tsx
+++ b/src/components/commons/icon-button.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { cva, VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import Image, { StaticImageData } from 'next/image';
+const iconButtonVariants = cva(
+  'flex items-center cursor-pointer rounded-full justify-center flex-shrink-0 backdrop-blur-[10px]',
+  {
+    variants: {
+      size: {
+        sm: 'w-7 h-7  bg-white/80  hover:bg-gray-300/80 ',
+        md: 'w-9 h-9 bg-white/80 aspect-square  hover:bg-gray-300/80',
+        lg: 'w-10 h-10  bg-transparent hover:bg-gray-100',
+        xl: 'w-11 h-11 bg-white/80  hover:bg-gray-300/80 '
+      }
+    },
+    defaultVariants: {
+      size: 'sm'
+    }
+  }
+);
+
+const iconImageVariants = cva('object-cover', {
+  variants: {
+    size: {
+      sm: 'w-3 h-3 ',
+      md: 'w-4 h-4',
+      lg: 'w-[1.375rem] h-[1.375rem]',
+      xl: 'w-5 h-5'
+    }
+  },
+  defaultVariants: {
+    size: 'sm'
+  }
+});
+
+export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof iconButtonVariants> & {
+    alt: string;
+    icon: StaticImageData;
+  };
+
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ alt, size, icon, className, ...props }, ref) => {
+    return (
+      <button ref={ref} className={cn(iconButtonVariants({ size }), className)} {...props}>
+        <Image src={icon} alt={alt} className={iconImageVariants({ size })} />
+      </button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';
+
+export { IconButton, iconButtonVariants };

--- a/src/components/commons/icon-button.tsx
+++ b/src/components/commons/icon-button.tsx
@@ -27,7 +27,12 @@ export type IconButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   ({ size, icon, alt, className, ...props }, ref) => {
     return (
-      <button ref={ref} className={cn(icon, iconButtonVariants({ size }), className)} {...props}>
+      <button
+        ref={ref}
+        type={props.type || 'button'}
+        className={cn(icon, iconButtonVariants({ size }), className)}
+        {...props}
+      >
         <span className="sr-only">{alt}</span>
       </button>
     );
@@ -36,4 +41,4 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
 
 IconButton.displayName = 'IconButton';
 
-export { IconButton, iconButtonVariants };
+export default IconButton;

--- a/src/components/commons/icon-button.tsx
+++ b/src/components/commons/icon-button.tsx
@@ -6,14 +6,14 @@ const iconButtonVariants = cva(
   {
     variants: {
       size: {
-        sm: ' w-7 h-7 bg-white/80  hover:bg-gray-300/80 before:h-3 before:w-3 ',
+        sm: 'w-7 h-7 bg-white/80  hover:bg-gray-300/80 before:h-3 before:w-3 ',
         md: 'w-9 h-9 bg-white/80 aspect-square  hover:bg-gray-300/80 before:h-4 before:w-4',
-        lg: 'h-10 w-10  bg-transparent hover:bg-gray-100 before:h-[1.375rem] before:w-[1.375rem]',
-        xl: 'h-11 w-11 bg-white/80  hover:bg-gray-300/80 before:h-5 before:w-5 '
+        lg: 'w-10 h-10  bg-transparent hover:bg-gray-100 before:h-[1.375rem] before:w-[1.375rem]',
+        xl: 'w-11 h-11 bg-white/80  hover:bg-gray-300/80 before:h-5 before:w-5 '
       }
     },
     defaultVariants: {
-      size: 'sm'
+      size: 'lg'
     }
   }
 );

--- a/src/components/commons/icon-button.tsx
+++ b/src/components/commons/icon-button.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
-import Image, { StaticImageData } from 'next/image';
 const iconButtonVariants = cva(
-  'flex items-center cursor-pointer rounded-full justify-center flex-shrink-0 backdrop-blur-[10px]',
+  'flex items-center object-contain cursor-pointer  rounded-full justify-center flex-shrink-0 backdrop-blur-[10px] bg-no-repeat bg-center before:content-[""] before:bg-contain before:bg-no-repeat before:block ',
   {
     variants: {
       size: {
-        sm: 'w-7 h-7  bg-white/80  hover:bg-gray-300/80 ',
-        md: 'w-9 h-9 bg-white/80 aspect-square  hover:bg-gray-300/80',
-        lg: 'w-10 h-10  bg-transparent hover:bg-gray-100',
-        xl: 'w-11 h-11 bg-white/80  hover:bg-gray-300/80 '
+        sm: ' w-7 h-7 bg-white/80  hover:bg-gray-300/80 before:h-3 before:w-3 ',
+        md: 'w-9 h-9 bg-white/80 aspect-square  hover:bg-gray-300/80 before:h-4 before:w-4',
+        lg: 'h-10 w-10  bg-transparent hover:bg-gray-100 before:h-[1.375rem] before:w-[1.375rem]',
+        xl: 'h-11 w-11 bg-white/80  hover:bg-gray-300/80 before:h-5 before:w-5 '
       }
     },
     defaultVariants: {
@@ -19,31 +18,17 @@ const iconButtonVariants = cva(
   }
 );
 
-const iconImageVariants = cva('object-cover shrink-0 ', {
-  variants: {
-    size: {
-      sm: 'w-3 h-3 ',
-      md: 'w-4 h-4',
-      lg: 'w-[1.375rem] h-[1.375rem]',
-      xl: 'w-5 h-5'
-    }
-  },
-  defaultVariants: {
-    size: 'sm'
-  }
-});
-
-export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+export type IconButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> &
   VariantProps<typeof iconButtonVariants> & {
     alt: string;
-    icon: StaticImageData;
+    icon: string;
   };
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ alt, size, icon, className, ...props }, ref) => {
+  ({ size, icon, alt, className, ...props }, ref) => {
     return (
-      <button ref={ref} className={cn(iconButtonVariants({ size }), className)} {...props}>
-        <Image src={icon} alt={alt} className={iconImageVariants({ size })} />
+      <button ref={ref} className={cn(icon, iconButtonVariants({ size }), className)} {...props}>
+        <span className="sr-only">{alt}</span>
       </button>
     );
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -148,7 +148,8 @@ const config: Config = {
         'sparkle-illustration': "url('/illustration/cta-banner-sparkle.svg')",
         'image-upload-illustration': "url('/illustrations/image-upload.svg')",
         'ai-sparkle-1': "url('/illustrations/ai-sparkle-1.svg')",
-        'ai-sparkle-2': "url('/illustrations/ai-sparkle-2.svg')"
+        'ai-sparkle-2': "url('/illustrations/ai-sparkle-2.svg')",
+        'close-line-icon' : 'url(/icons/close_line.svg)'
       },
       letterSpacing: {
         snug: '-0.0175rem'


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #97 
<br>

## 📝 작업 내용

- 아이콘 버튼형 컴포넌트를 추가하였습니다.

- `lg` 크기는 배경이 `transparent`입니다.
- `icon`인자는 클래스에 커스텀으로 `before: bg-아이콘 이미지`으로 전달하시면 됩니다.  
<br>

* 사용방법 : 
```tsx

import { IconButton } from '@/components/commons/icon-button';
const HomePage = () => {
  return (
    <div className="flex items-center justify-center gap-4">
      <IconButton icon="before:bg-close-line-icon" alt="닫기 버튼" size="sm" />
      <IconButton icon="before:bg-close-line-icon" alt="닫기 버튼" size="md" />
      <IconButton icon="before:bg-close-line-icon" alt="닫기 버튼" size="lg" />
      <IconButton icon="before:bg-close-line-icon" alt="닫기 버튼" size="xl" />
    </div>
  );
};

export default HomePage;



```


## 🖼 스크린샷


https://github.com/user-attachments/assets/b12c08f8-b8fb-4e0e-bfbc-47cf4a4e73a8



<br>

## 💬 리뷰 요구사항

> 리뷰시간 `5분`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새 기능**
	- 아이콘을 표시하는 새로운 버튼 컴포넌트가 추가되어, 다양한 크기 옵션과 반응형 디자인을 지원합니다.
	- 이를 통해 사용자 인터페이스가 더욱 직관적이고 유연하게 개선되었습니다.
	- 새로운 배경 이미지 설정이 추가되어, 아이콘 버튼에 사용할 수 있는 'close-line-icon'이 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->