### PR TITLE
Design/#143 네비게이션 메뉴바 위치 이동

### DIFF
--- a/src/components/layouts/global-navigation-bar.tsx
+++ b/src/components/layouts/global-navigation-bar.tsx
@@ -22,7 +22,7 @@ const GlobalNavigationBar = () => {
     <nav
       className={cn(
         'fixed bottom-4 left-4 right-4 rounded-[6.25rem] bg-gray-200/[0.64] p-2',
-        'temp-layout !left-1/2 right-0 !m-0 w-full -translate-x-1/2'
+        'temp-layout left-1/2 right-0 !m-0 w-full -translate-x-1/2'
       )}
     >
       <ul className="flex gap-2">

--- a/src/components/layouts/global-navigation-bar.tsx
+++ b/src/components/layouts/global-navigation-bar.tsx
@@ -22,7 +22,7 @@ const GlobalNavigationBar = () => {
     <nav
       className={cn(
         'fixed bottom-4 left-4 right-4 rounded-[6.25rem] bg-gray-200/[0.64] p-2',
-        'temp-layout left-1/2 right-0 w-full -translate-x-1/2'
+        'temp-layout !left-1/2 right-0 !m-0 w-full -translate-x-1/2'
       )}
     >
       <ul className="flex gap-2">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #143

<br>

## 📝 작업 내용

- 네비게이션 메뉴바 위치 이동
- 이전에 메뉴바가 중앙에 있지 않아, 중앙에 위치하도록 수정했습니다.

<br>

## 🖼 스크린샷
![스크린샷 2025-04-16 오후 11 10 21](https://github.com/user-attachments/assets/df8562fc-4234-4626-b870-aec3a5294938)

<br>

## 💬 리뷰 요구사항

- 리뷰 예상 시간 :`1분`
