### PR TITLE
Design/#145 home meal card memo

### DIFF
--- a/src/components/_home/home-meal-card-memo.tsx
+++ b/src/components/_home/home-meal-card-memo.tsx
@@ -9,7 +9,7 @@ const HomeMealCardMemo = ({ memo }: { memo: string }) => {
         'before:bg-edit-4-icon before:h-[1.125rem] before:w-[1.125rem] before:bg-contain before:bg-center before:bg-no-repeat'
       )}
     >
-      <Typography variant="body3" className="text-gray-700">
+      <Typography variant="body3" className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-gray-700">
         {memo}
       </Typography>
     </div>

--- a/src/components/_home/home-meal-card.tsx
+++ b/src/components/_home/home-meal-card.tsx
@@ -18,7 +18,7 @@ const HomeMealCard = ({ meal }: HomeMealCardProps) => {
     <li className="flex gap-3">
       <HomeMealCardTimeIndicator mealIcon={mealIcon} ateAt={meal.ateAt} />
       {/* TODO : Link 태그로 변경 & 식사 상세 페이지로 이동하게끔!! */}
-      <div className="flex flex-1 flex-col gap-4 rounded-2xl bg-white p-4">
+      <div className="flex w-full flex-1 flex-col gap-4 overflow-hidden rounded-2xl bg-white p-4">
         <HomeMealCardTitle mealLabel={mealLabel} calories={calories} images={meal.foodImages} />
         <HomeMealCardMacronutrient {...macronutrients} />
         {meal.memo && <HomeMealCardMemo memo={meal.memo} />}

--- a/src/lib/apis/meal.api.ts
+++ b/src/lib/apis/meal.api.ts
@@ -221,7 +221,8 @@ export const getAllMyDailyCalories = async (
   const mealCalories = mealData.reduce<Record<string, { calories: number; caloriesGoal: number }>>((acc, meal) => {
     const caloriesSum = meal.meal_details.reduce((sum, mealDetail) => sum + mealDetail.calories, 0);
     const ateAt = formatDateWithDash(new Date(meal.ate_at));
-    acc[ateAt] = { calories: caloriesSum, caloriesGoal: userData.daily_calories_goal };
+    acc[ateAt].calories += caloriesSum;
+    acc[ateAt].caloriesGoal = userData.daily_calories_goal;
     return acc;
   }, res);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #145 

<br>

## 📝 작업 내용

- 식사 카드에서 말줄임 추가했습니다.
- 캘린더에서 하루 식단 칼로리 합을 구하는 로직 오류 수정
  - 하루에 여러끼니의 식사를 할 수 있습니다.
  - 이전 로직은 마지막에 존재하는 식사의 칼로리 합만 제공하는 문제가 있습닏.
  - 계속하여 합하도록 수정했습니다.

<br>

## 🖼 스크린샷
![image](https://github.com/user-attachments/assets/788e3977-b130-47c0-bdb1-b6e3b0e5f0ea)

<br>

## 💬 리뷰 요구사항

- 리뷰 예상 시간 :`10분`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 여러 끼니가 같은 날짜에 기록될 때, 일일 칼로리 합계가 올바르게 누적되어 표시됩니다.
- **스타일**
  - 식사 카드와 메모 텍스트의 레이아웃 및 표시 방식이 개선되어, 텍스트가 한 줄로 표시되고 넘칠 경우 말줄임표로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->