### PR TITLE
Feature/#148 목표 설정 미반영 로직 수정

### DIFF
--- a/src/components/_set-goal/set-goal-calculate-step.tsx
+++ b/src/components/_set-goal/set-goal-calculate-step.tsx
@@ -21,6 +21,9 @@ import { isClient } from '@/lib/utils/predicate.util';
 import { formatNumberWithComma } from '@/lib/utils/format-number-with-comma';
 import { CompleteType } from '@/types/set-goal.type';
 import USER_PHYSICAL_PROFILE_SCHEMA from '@/constants/user-schema.constant';
+import { useUserStore } from '@/lib/hooks/use-user-store';
+import { useRouter } from 'next/navigation';
+import { revalidateFunction } from '@/lib/utils/revalidate.util';
 
 type SetGoalCalculateStepProps = {
   userName: string;
@@ -40,6 +43,8 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 const SetGoalCalculateStep = ({ nextStep, userName, data }: SetGoalCalculateStepProps) => {
+  const { refresh } = useUserStore();
+  const router = useRouter();
   let userPersonalGoal = {
     dailyCaloriesGoal: 0,
     dailyCarbohydrateGoal: 0,
@@ -86,9 +91,13 @@ const SetGoalCalculateStep = ({ nextStep, userName, data }: SetGoalCalculateStep
 
   const handleSubmit = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+
     try {
       await updateUserPersonalInfo(userPersonalInfos);
+      refresh();
       nextStep('complete');
+      // TODO 더 좋은 방법을 찾걿아
+      revalidateFunction();
     } catch (error) {
       console.error('목표 계산 및 업데이트 중 오류 발생:', error);
     }

--- a/src/components/_set-goal/set-goal-calculate-step.tsx
+++ b/src/components/_set-goal/set-goal-calculate-step.tsx
@@ -22,7 +22,6 @@ import { formatNumberWithComma } from '@/lib/utils/format-number-with-comma';
 import { CompleteType } from '@/types/set-goal.type';
 import USER_PHYSICAL_PROFILE_SCHEMA from '@/constants/user-schema.constant';
 import { useUserStore } from '@/lib/hooks/use-user-store';
-import { useRouter } from 'next/navigation';
 import { revalidateFunction } from '@/lib/utils/revalidate.util';
 
 type SetGoalCalculateStepProps = {
@@ -44,7 +43,7 @@ type FormValues = z.infer<typeof formSchema>;
 
 const SetGoalCalculateStep = ({ nextStep, userName, data }: SetGoalCalculateStepProps) => {
   const { refresh } = useUserStore();
-  const router = useRouter();
+
   let userPersonalGoal = {
     dailyCaloriesGoal: 0,
     dailyCarbohydrateGoal: 0,

--- a/src/lib/utils/revalidate.util.ts
+++ b/src/lib/utils/revalidate.util.ts
@@ -1,0 +1,8 @@
+'use server';
+
+import SITE_MAP from '@/constants/site-map.constant';
+import { revalidatePath } from 'next/cache';
+
+export const revalidateFunction = async () => {
+  revalidatePath(SITE_MAP.HOME);
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #148

<br>

## 📝 작업 내용

- 목표를 미설정한 채로 식단 기록만 했을 때 추후 목표 설정을 하면 바로 피드백이 반영되도록 구현
- 목표 설정이 완료되면 store refresh 와 home 을 revalidatePath 하는 로직

<br>

## 💬 리뷰 요구사항

> - 리뷰 예상 시간 : `5분`
