### PR TITLE
Fix/#156 키, 몸무게 입력 폼 소수점도 가능하도록 수정

### DIFF
--- a/src/components/_set-goal/set-goal-height-step.tsx
+++ b/src/components/_set-goal/set-goal-height-step.tsx
@@ -59,6 +59,7 @@ const SetGoalHeightStep = ({ userName, nextStep }: SetGoalHeightStepProps) => {
                           type="number"
                           inputMode="numeric"
                           measure="cm"
+                          step="0.1"
                           min="50"
                           max="250"
                           className="mb-2"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #156 

<br>

## 📝 작업 내용

- 키 소수점 입력 가능하도록 수정
- 몸무게 소수 입력하더라도 테이블에 업로드되도록 테이블 타입 수정


<br>

## 💬 리뷰 요구사항

> 리뷰 예상 시간 : 10초
