### PR TITLE
Refactor/#175 목표 설정 qa 반영

### DIFF
--- a/src/app/(auth)/sign-up/components/auth-sign-up-funnel.tsx
+++ b/src/app/(auth)/sign-up/components/auth-sign-up-funnel.tsx
@@ -17,7 +17,7 @@ import {
 import { z } from 'zod';
 
 const AuthSignUpFunnel = () => {
-  const Funnel = useFunnel<SignUpFunnelType, SignUpFunnelStep>('step1', signUpValidateFn, 'sign-up-funnel-data');
+  const { Funnel } = useFunnel<SignUpFunnelType, SignUpFunnelStep>('step1', signUpValidateFn, 'sign-up-funnel-data');
 
   return (
     <Funnel

--- a/src/app/(client)/set-goal/components/set-goal-funnel.tsx
+++ b/src/app/(client)/set-goal/components/set-goal-funnel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Suspense, useEffect } from 'react';
 import { z } from 'zod';
 import useFunnel from '@/hooks/use-funnel';

--- a/src/app/(client)/set-goal/components/set-goal-funnel.tsx
+++ b/src/app/(client)/set-goal/components/set-goal-funnel.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { z } from 'zod';
 import useFunnel from '@/hooks/use-funnel';
 import { ActivityLevelType, GenderType, PurposeType } from '@/types/user-personal-info.type';
@@ -40,7 +40,7 @@ const validateStep = {
 };
 
 const SetGoalFunnel = ({ userName }: SetGoalFunnelProps) => {
-  const Funnel = useFunnel<
+  const { Funnel, currentStep } = useFunnel<
     {
       step1: StepPurposeType;
       step2: StepGenderType;
@@ -68,6 +68,10 @@ const SetGoalFunnel = ({ userName }: SetGoalFunnelProps) => {
     },
     'session-key'
   );
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [currentStep]);
 
   return (
     <Suspense>

--- a/src/app/(client)/set-goal/components/step-activity-level.tsx
+++ b/src/app/(client)/set-goal/components/step-activity-level.tsx
@@ -33,7 +33,7 @@ const StepActivityLevel = ({ userName, nextStep }: StepActivityLevelProps) => {
             생활 패턴에 가장 가까운 걸 선택해 주세요
           </Typography>
         </legend>
-        <div className="space-y-2 pt-8">
+        <div className="mt-8 space-y-2 pt-2">
           {GOAL_OPTIONS.ACTIVITY_LEVEL_OPTIONS.map((option) => (
             <OptionSelectCard
               key={option.value}

--- a/src/app/(client)/set-goal/components/step-age.tsx
+++ b/src/app/(client)/set-goal/components/step-age.tsx
@@ -64,7 +64,7 @@ const StepAge = ({ userName, nextStep }: StepAgeProps) => {
             </div>
             <Button
               type="submit"
-              className="fixed bottom-6 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
+              className="fixed bottom-[calc(env(safe-area-inset-bottom,1.5rem)+1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
               disabled={!form.watch('age')}
             >
               다음

--- a/src/app/(client)/set-goal/components/step-calculate.tsx
+++ b/src/app/(client)/set-goal/components/step-calculate.tsx
@@ -148,7 +148,7 @@ const StepCalculate = ({ nextStep, userName, data }: StepCalculateProps) => {
           </div>
         </form>
       </Form>
-      <div className="space-y-2">
+      <div className="space-y-2 pb-40">
         <Typography as="span" variant="body3" className="ml-1">
           목표 칼로리 기준 영양소 권장량
         </Typography>
@@ -158,7 +158,7 @@ const StepCalculate = ({ nextStep, userName, data }: StepCalculateProps) => {
           <MacronutrientBox label="FAT" data={macronutrientData.fat} />
         </div>
       </div>
-      <div className="fixed bottom-4 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2">
+      <div className="fixed bottom-[calc(env(safe-area-inset-bottom,1.5rem)+1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2">
         <Button onClick={handleSubmit} className="w-full">
           목표 설정하기
         </Button>

--- a/src/app/(client)/set-goal/components/step-calculate.tsx
+++ b/src/app/(client)/set-goal/components/step-calculate.tsx
@@ -162,7 +162,10 @@ const StepCalculate = ({ nextStep, userName, data }: StepCalculateProps) => {
         <Button onClick={handleSubmit} className="w-full">
           목표 설정하기
         </Button>
-        <Button onClick={() => nextStep('step1')} className="mt-2 w-full bg-transparent text-gray-600">
+        <Button
+          onClick={() => nextStep('step1')}
+          className="mt-2 w-full bg-transparent text-gray-600 hover:bg-transparent"
+        >
           목표 다시 설정하기
         </Button>
       </div>

--- a/src/app/(client)/set-goal/components/step-gender.tsx
+++ b/src/app/(client)/set-goal/components/step-gender.tsx
@@ -32,7 +32,7 @@ const StepGender = ({ userName, nextStep }: StepGenderProps) => {
             성별에 따라 기초대사량 계산이 달라져요
           </Typography>
         </legend>
-        <div className="space-y-2 pt-2">
+        <div className="mt-8 space-y-2 pt-2">
           {GOAL_OPTIONS.GENDER.map((option) => (
             <OptionSelectCard
               key={option.value}

--- a/src/app/(client)/set-goal/components/step-gender.tsx
+++ b/src/app/(client)/set-goal/components/step-gender.tsx
@@ -43,7 +43,10 @@ const StepGender = ({ userName, nextStep }: StepGenderProps) => {
             />
           ))}
         </div>
-        <Button disabled={!selectedOption} className="fixed bottom-6 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2">
+        <Button
+          disabled={!selectedOption}
+          className="fixed bottom-[calc(env(safe-area-inset-bottom,1.5rem)+1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
+        >
           다음
         </Button>
       </fieldset>

--- a/src/app/(client)/set-goal/components/step-height.tsx
+++ b/src/app/(client)/set-goal/components/step-height.tsx
@@ -74,7 +74,7 @@ const StepHeight = ({ userName, nextStep }: StepHeightProps) => {
             </div>
             <Button
               type="submit"
-              className="fixed bottom-6 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
+              className="fixed bottom-[calc(env(safe-area-inset-bottom,1.5rem)+1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
               disabled={!form.watch('height')}
             >
               다음

--- a/src/app/(client)/set-goal/components/step-purpose.tsx
+++ b/src/app/(client)/set-goal/components/step-purpose.tsx
@@ -33,7 +33,7 @@ const StepPurpose = ({ userName, nextStep }: StepPurposeProps) => {
             목표에 따라 칼로리와 영양소 비율이 달라져요
           </Typography>
         </legend>
-        <div className="space-y-2 pt-2">
+        <div className="mt-8 space-y-2 pt-2">
           {GOAL_OPTIONS.PURPOSE.map((option) => (
             <OptionSelectCard
               key={option.value}
@@ -44,7 +44,10 @@ const StepPurpose = ({ userName, nextStep }: StepPurposeProps) => {
             />
           ))}
         </div>
-        <Button disabled={!selectedOption} className="fixed bottom-6 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2">
+        <Button
+          disabled={!selectedOption}
+          className="fixed bottom-[env(safe-area-inset-bottom,1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
+        >
           다음
         </Button>
       </fieldset>

--- a/src/app/(client)/set-goal/components/step-purpose.tsx
+++ b/src/app/(client)/set-goal/components/step-purpose.tsx
@@ -46,7 +46,7 @@ const StepPurpose = ({ userName, nextStep }: StepPurposeProps) => {
         </div>
         <Button
           disabled={!selectedOption}
-          className="fixed bottom-[env(safe-area-inset-bottom,1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
+          className="fixed bottom-[calc(env(safe-area-inset-bottom,1.5rem)+1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
         >
           다음
         </Button>

--- a/src/app/(client)/set-goal/components/step-weight.tsx
+++ b/src/app/(client)/set-goal/components/step-weight.tsx
@@ -65,7 +65,7 @@ const StepWeight = ({ userName, nextStep }: StepWeightProps) => {
             </div>
             <Button
               type="submit"
-              className="fixed bottom-6 left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
+              className="fixed bottom-[calc(env(safe-area-inset-bottom,1.5rem)+1.5rem)] left-1/2 w-[calc(100%-2.5rem)] -translate-x-1/2"
               disabled={!form.watch('weight')}
             >
               다음

--- a/src/app/(client)/set-goal/page.tsx
+++ b/src/app/(client)/set-goal/page.tsx
@@ -36,7 +36,7 @@ const SetGoalPage = () => {
     return <GlassBackground className="relative space-y-8">{content}</GlassBackground>;
   }
 
-  return <div className="relative min-h-[calc(100vh-64px)] space-y-8">{content}</div>;
+  return <div className="relative min-h-[calc(100vh-4rem)] space-y-8">{content}</div>;
 };
 
 export default SetGoalPage;

--- a/src/app/(client)/set-goal/page.tsx
+++ b/src/app/(client)/set-goal/page.tsx
@@ -36,7 +36,7 @@ const SetGoalPage = () => {
     return <GlassBackground className="relative space-y-8">{content}</GlassBackground>;
   }
 
-  return <div className="relative min-h-[calc(100vh-60px)] space-y-8">{content}</div>;
+  return <div className="relative min-h-[calc(100vh-64px)] space-y-8">{content}</div>;
 };
 
 export default SetGoalPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,10 @@ const wantedSans = localFont({
 
 export const metadata: Metadata = {
   title: 'Todayeat',
-  description: '사진을 찍기만 하면 음식을 자동으로 인식하고 영양 정보를 기록해주는 웹 애플리케이션.'
+  description: '사진을 찍기만 하면 음식을 자동으로 인식하고 영양 정보를 기록해주는 웹 애플리케이션.',
+  viewport: {
+    viewportFit: 'cover'
+  }
 };
 
 const RootLayout = ({

--- a/src/components/commons/ai-loader-lottie.tsx
+++ b/src/components/commons/ai-loader-lottie.tsx
@@ -4,14 +4,14 @@ import AiLoaderBg from '@/../public/lottie/ai-loader-bg.json';
 
 const AiLoaderLottie = () => {
   return (
-    <div className="relative">
+    <div className="relative h-40 w-40">
       <Lottie
         loop
         play
         animationData={AiLoaderStar}
-        className="absolute left-1/2 top-1/2 w-full -translate-x-1/2 -translate-y-1/2"
+        className="absolute left-1/2 top-1/2 w-full -translate-x-1/2 -translate-y-1/2 object-contain"
       />
-      <Lottie loop play animationData={AiLoaderBg} className="h-40 w-40" />
+      <Lottie loop play animationData={AiLoaderBg} className="h-full w-full object-contain" />
     </div>
   );
 };

--- a/src/hooks/use-funnel.tsx
+++ b/src/hooks/use-funnel.tsx
@@ -63,9 +63,10 @@ type FunnelComponentProps<K extends Record<string, unknown>, T extends Extract<k
  * useFunnel 훅의 반환 타입
  * Funnel 컴포넌트
  */
-type UseFunnelReturnType<K extends Record<string, unknown>, T extends Extract<keyof K, string>> = (
-  props: FunnelComponentProps<K, T>
-) => JSX.Element;
+type UseFunnelReturnType<K extends Record<string, unknown>, T extends Extract<keyof K, string>> = {
+  Funnel: (props: FunnelComponentProps<K, T>) => JSX.Element;
+  currentStep: T;
+};
 
 /**
  * 다단계 폼 프로세스(funnel)를 쉽게 관리하기 위한 커스텀 훅
@@ -158,7 +159,7 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
     return props[currentStep]({ setStep, data: funnelData as K[T], clearFunnelData });
   };
 
-  return Funnel;
+  return { Funnel, currentStep };
 };
 
 export default useFunnel;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #175

<br>

## 📝 작업 내용

- 목표 설정하기 타이틀과 옵션 카드 사이 여백 추가
- 버튼 하단 고정 이슈
- 단계 넘어갈 때 스크롤 초기화
- ai-loader-bg 잘림 이슈 해결
- 목표 설정 완료 페이지 에셋 위치 조정

<br>

## 🖼 스크린샷
![Screenshot 2025-04-20 at 14 15 08](https://github.com/user-attachments/assets/808d5444-9988-4cd4-8992-c61abfced4b6)



<br>

## 💬 리뷰 요구사항

> - 리뷰 예상 시간 : `10분`
> - 버튼 하단 고정 이슈에 관한 내용입니다. 기존에도 하단에 고정은 되어 있었으나 ios 기기의 경우 아이폰 X 모델 이후로 상/하단 라운드 영역과 노치 존이 존재해 콘텐츠가 보이지 않고 잘리는 구간이 있습니다. 하여 안정적으로 콘텐츠를 노출할 수 있는 Safe Area가 있는데요, 
![image](https://github.com/user-attachments/assets/c33e802f-ebd9-4aa3-afec-e6449625694e)
> 기존 하단 버튼 역시 safe Area에서 벗어난 곳에서 노출되고 있어 버튼이 원 스크롤 내에서 보이지 않던 이슈로 예상하고 있습니다. 
> 해결을 위해 `env(safe-area-inset-bottom)` 속성을 사용해 둔 상태이며 실제로 디바이스에서 잘 적용되고 있는지 확인을 위해서는 배포 후 기기 테스트가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 여러 버튼과 컨테이너의 하단 여백이 기기 안전 영역(safe area)을 반영하도록 개선되어, 노치나 홈 인디케이터가 있는 기기에서 UI가 더 잘 보이도록 변경되었습니다.
  - 일부 옵션 선택 영역의 상단 여백 및 내부 패딩이 조정되어 화면 레이아웃이 개선되었습니다.
  - Lottie 애니메이션의 크기 및 정렬이 개선되어 시각적으로 더 깔끔하게 표시됩니다.
  - 페이지 컨테이너의 최소 높이 계산이 소폭 조정되었습니다.

- **신규 기능**
  - 목표 설정 단계 전환 시 화면이 자동으로 맨 위로 스크롤되어 사용자 경험이 향상되었습니다.

- **리팩터**
  - 목표 설정 단계 관리 로직이 개선되어, 현재 단계를 외부에서 직접 확인할 수 있게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->