### PR TITLE
Design/#201 sign in pc page

### DIFF
--- a/src/app/(auth)/sign-in/layout.tsx
+++ b/src/app/(auth)/sign-in/layout.tsx
@@ -7,10 +7,12 @@ const Layout = ({
   children: React.ReactNode;
 }>) => {
   return (
-    <div className="temp-layout">
+    <div className="layout-container">
       <Header variant="backButton" />
-      <main className="pt-layout">{children}</main>
-      <Footer />
+      <div className="desktop-width mx-auto flex flex-col items-center justify-center pt-layout xl:min-h-[100vh] xl:pt-20">
+        <main className="w-full">{children}</main>
+        <Footer />
+      </div>
     </div>
   );
 };

--- a/src/app/(auth)/sign-in/layout.tsx
+++ b/src/app/(auth)/sign-in/layout.tsx
@@ -9,7 +9,7 @@ const Layout = ({
   return (
     <div className="layout-container">
       <Header variant="backButton" />
-      <div className="desktop-width mx-auto flex min-h-screen flex-col items-center justify-center">
+      <div className="desktop-width mx-auto flex min-h-screen flex-col items-center justify-center pt-layout xl:pt-0">
         <main className="w-full">{children}</main>
         <Footer />
       </div>

--- a/src/app/(auth)/sign-in/layout.tsx
+++ b/src/app/(auth)/sign-in/layout.tsx
@@ -9,7 +9,7 @@ const Layout = ({
   return (
     <div className="layout-container">
       <Header variant="backButton" />
-      <div className="desktop-width mx-auto flex flex-col items-center justify-center pt-layout xl:min-h-[100vh] xl:pt-20">
+      <div className="desktop-width mx-auto flex min-h-screen flex-col items-center justify-center">
         <main className="w-full">{children}</main>
         <Footer />
       </div>

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -10,8 +10,8 @@ import GlassBackground from '@/components/commons/glass-background';
 
 const SignInPage = () => {
   return (
-    <section>
-      <div className="gap flex flex-col items-center gap-2 px-4 pb-7 pt-2">
+    <section className="">
+      <div className="gap flex flex-col items-center gap-2 px-4 pb-7 pt-2 xl:pt-0">
         <h2>
           <Link href={SITE_MAP.HOME}>
             <Image src={LOGO} alt="투데잇 로고" className="h-[38px] w-[137px]" />
@@ -21,7 +21,7 @@ const SignInPage = () => {
           사진 한 장으로 완성되는 식단 기록
         </Typography>
       </div>
-      <GlassBackground className="min-h-0 space-y-6 rounded-[2rem] px-5 pb-8 pt-7">
+      <GlassBackground className="min-h-0 space-y-6 rounded-[2rem] px-5 pb-8 pt-7 xl:p-10">
         <SignInForm />
         <div className="flex flex-col gap-2">
           <KakaoSignInButton />

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -10,7 +10,7 @@ import GlassBackground from '@/components/commons/glass-background';
 
 const SignInPage = () => {
   return (
-    <section className="">
+    <section>
       <div className="gap flex flex-col items-center gap-2 px-4 pb-7 pt-2 xl:pt-0">
         <h2>
           <Link href={SITE_MAP.HOME}>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #201

<br>

## 📝 작업 내용

- 로그인 페이지 PC 디자인 반영

<br>

## 🖼 스크린샷

![image](https://github.com/user-attachments/assets/d4ea7d9d-a3e1-4540-ae43-26760592f6be)
![스크린샷 2025-04-22 오후 8 05 34](https://github.com/user-attachments/assets/142d2406-0aca-42d6-804f-35d63405bbe6)


<br>

## 💬 리뷰 요구사항

- 리뷰 예상 시간 :`5분`
- 전체 layout에 padding-top이 없다면 모바일에서는 header와 겹치는 문제가 있었습니다.
- 디자이너님께 여쭈었더니, 그럼 모바일일때는 padding-top을 주고 pc일때는 padding-top이 없게 하자고 하셔서 반영했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 로그인 페이지의 레이아웃과 패딩이 개선되어 데스크톱 및 대형 화면에서 콘텐츠가 더 잘 정렬되고 여백이 최적화되었습니다.
  - 대형 화면에서 상단 여백과 컨테이너 패딩이 조정되어 더욱 깔끔한 시각적 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->