### PR TITLE
Bug fix/#217 use funnel rerendering fix

### DIFF
--- a/src/hooks/use-funnel.tsx
+++ b/src/hooks/use-funnel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { isServer } from '@/utils/predicate.util';

--- a/src/hooks/use-funnel.tsx
+++ b/src/hooks/use-funnel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { isServer } from '@/utils/predicate.util';
@@ -98,14 +98,16 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
   };
 
   const currentStep = getInitialStep(stepInQueryParam, initialStep);
-  const [funnelData, setFunnelData] = useState<Partial<K[T]>>({});
+
+  const funnelDataRef = useRef<Partial<K[T]>>({});
+  let funnelData = funnelDataRef.current;
 
   useEffect(() => {
     if (isServer()) return;
 
     const funnelSessionData = getSessionStorageItem(sessionId, {} as K[T]);
 
-    setFunnelData(funnelSessionData);
+    funnelDataRef.current = funnelSessionData;
 
     if (!validateStep[currentStep](funnelSessionData)) {
       const newSearchParams = new URLSearchParams(searchParams.toString());
@@ -124,7 +126,7 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
 
   const clearFunnelData = () => {
     removeSessionStorageItem(sessionId);
-    setFunnelData({});
+    funnelDataRef.current = {};
   };
 
   const setStepImplementation = <NextStep extends T>(
@@ -141,7 +143,7 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
       return;
     }
 
-    setFunnelData(newData);
+    funnelDataRef.current = newData;
     setSessionStorageItem(sessionId, newData);
 
     const newSearchParams = new URLSearchParams(searchParams.toString());

--- a/src/hooks/use-funnel.tsx
+++ b/src/hooks/use-funnel.tsx
@@ -100,7 +100,6 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
   const currentStep = getInitialStep(stepInQueryParam, initialStep);
 
   const funnelDataRef = useRef<Partial<K[T]>>({});
-  let funnelData = funnelDataRef.current;
 
   useEffect(() => {
     if (isServer()) return;
@@ -135,7 +134,7 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
   ): void => {
     if (currentStep === nextStep) return;
 
-    const newData = { ...funnelData, ...(currentStepData || {}) } as K[NextStep];
+    const newData = { ...funnelDataRef.current, ...(currentStepData || {}) } as K[NextStep];
 
     if (!validateStep[nextStep](newData)) {
       alert('비정상적인 접근입니다.');
@@ -158,7 +157,7 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
   };
 
   const Funnel = (props: FunnelComponentProps<K, T>) => {
-    return props[currentStep]({ setStep, data: funnelData as K[T], clearFunnelData });
+    return props[currentStep]({ setStep, data: funnelDataRef.current as K[T], clearFunnelData });
   };
 
   return { Funnel, currentStep };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #217 

<br>

## 📝 작업 내용

- useFunnel에서 발생하는 불필요한 리렌더링 제거 
  - useState가 아닌 useRef를 통해 값을 저장하도록 수정
  - router push를 통해 리렌더링을 시켜줌으로 useRef 사용 가능

<br>

## 🖼 스크린샷
디자인 변경사항 없습니다.

<br>

## 💬 리뷰 요구사항

- 리뷰 예상 시간 :`1분`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - 퍼널 데이터의 내부 관리 방식이 변경되어, 퍼널 데이터 변경 시 불필요한 화면 리렌더링이 발생하지 않도록 개선되었습니다.  
  - 사용자 경험 및 기능에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->