### PR TITLE
Design/#215 pc header and navigation bar

### DIFF
--- a/src/app/(home)/components/home-calendar/home-calendar-client-view.tsx
+++ b/src/app/(home)/components/home-calendar/home-calendar-client-view.tsx
@@ -55,6 +55,7 @@ const HomeCalendarClientView = ({ dailyMealCalories }: HomeCalendarClientViewPro
           <Responsive
             mobile={<DateSelectorMobile open={isOpen} onOpenChange={setIsOpen} />}
             pc={<DateSelectorPc open={isOpen} onOpenChange={setIsOpen} />}
+            mode="js"
           />
         </div>
         <TabsContent value="week">

--- a/src/components/commons/responsive.tsx
+++ b/src/components/commons/responsive.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import useIsMobile from '@/hooks/use-is-mobile';
 import { ReactNode } from 'react';
 

--- a/src/components/commons/responsive.tsx
+++ b/src/components/commons/responsive.tsx
@@ -6,9 +6,18 @@ import { ReactNode } from 'react';
 type ResponsiveProps = {
   pc: ReactNode;
   mobile: ReactNode;
+  mode?: 'css' | 'js';
 };
-const Responsive = ({ pc, mobile }: ResponsiveProps) => {
+const Responsive = ({ pc, mobile, mode = 'css' }: ResponsiveProps) => {
   const isMobile = useIsMobile();
+
+  if (mode === 'css')
+    return (
+      <>
+        <div className="xl:hidden">{mobile}</div>
+        <div className="hidden xl:block">{pc}</div>
+      </>
+    );
 
   if (isMobile) return mobile;
   return pc;

--- a/src/components/layouts/global-navigation-bar/index.tsx
+++ b/src/components/layouts/global-navigation-bar/index.tsx
@@ -3,12 +3,16 @@
 import { usePathname } from 'next/navigation';
 import GlobalNavigationBarItem from './item';
 import SITE_MAP from '@/constants/site-map.constant';
+import { HTMLAttributes } from 'react';
+import { cn } from '@/lib/shadcn';
 
 const HOME = 'home';
 const REPORT = 'report';
 const POST = 'post';
 
-const GlobalNavigationBar = () => {
+type GlobalNavigationBarProps = HTMLAttributes<HTMLElement>;
+
+const GlobalNavigationBar = ({ className, ...props }: GlobalNavigationBarProps) => {
   const pathname = usePathname();
 
   const currentPage = pathname.startsWith(SITE_MAP.MEAL_POST)
@@ -18,9 +22,15 @@ const GlobalNavigationBar = () => {
       : HOME;
 
   return (
-    <nav className="temp-layout fixed bottom-4 left-4 right-4 rounded-[6.25rem] bg-gray-200/[0.64] p-2 backdrop-blur-[30px]">
-      <ul className="flex gap-2">
-        <li className="flex-1">
+    <nav
+      className={cn(
+        'fixed bottom-4 left-4 right-4 rounded-[6.25rem] bg-gray-200/[0.64] p-2 backdrop-blur-[30px] layout-container xl:hidden',
+        className
+      )}
+      {...props}
+    >
+      <ul className="grid grid-cols-3 gap-2">
+        <li>
           <GlobalNavigationBarItem
             href={SITE_MAP.HOME}
             label="홈"
@@ -28,7 +38,7 @@ const GlobalNavigationBar = () => {
             active={currentPage === HOME}
           />
         </li>
-        <li className="flex-1">
+        <li>
           <GlobalNavigationBarItem
             href={SITE_MAP.MEAL_POST}
             label="식사 기록"
@@ -36,7 +46,7 @@ const GlobalNavigationBar = () => {
             active={currentPage === POST}
           />
         </li>
-        <li className="flex-1">
+        <li>
           <GlobalNavigationBarItem
             href={SITE_MAP.REPORT}
             label="리포트"

--- a/src/components/layouts/global-navigation-bar/item.tsx
+++ b/src/components/layouts/global-navigation-bar/item.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/shadcn';
 import { Typography } from '@/components/ui/typography';
 
 const gnbItemStyle = cva(
-  'flex items-center text-center justify-center gap-2 p-2 rounded-[1.5625rem] transition-color before:content-[""] before:block before:w-[1.375rem] before:h-[1.375rem] before:bg-contain before:bg-no-repeat before:bg-center',
+  'flex items-center text-center justify-center gap-2 p-2 xl:px-3 rounded-[1.5625rem] transition-color before:content-[""] before:block before:w-[1.375rem] before:h-[1.375rem] before:bg-contain before:bg-no-repeat before:bg-center',
   {
     variants: {
       active: {
@@ -27,7 +27,7 @@ type GnbItemProps = {
 
 const GlobalNavigationBarItem = ({ href, icon, label, active }: GnbItemProps) => (
   <Link href={href} className={cn(gnbItemStyle({ active }), icon)}>
-    <Typography as="span" variant="subTitle5" className="!leading-none">
+    <Typography as="span" variant="subTitle5" className="whitespace-nowrap !leading-none">
       {label}
     </Typography>
   </Link>

--- a/src/components/layouts/header/index.tsx
+++ b/src/components/layouts/header/index.tsx
@@ -1,43 +1,9 @@
-'use client';
+import Responsive from '@/components/commons/responsive';
+import MobileHeader, { MobileHeaderProps } from './mobile-header';
+import PcHeader from './pc-header';
 
-import { cn } from '@/lib/shadcn';
-import { useDetectIsScrolled } from '@/hooks/use-detect-is-scrolled';
-import BackButton from './variants/back-button';
-import Default from './variants/default';
-import WithProfile from './variants/with-profile';
-
-type HeaderVariants = 'backButton' | 'default' | 'withProfile';
-
-type HeaderProps = {
-  variant?: HeaderVariants; // ❗️여기 optional로 바꿔주기
-};
-
-const Header = ({ variant = 'default' }: HeaderProps) => {
-  const isScrolled = useDetectIsScrolled();
-
-  const renderVariant = () => {
-    switch (variant) {
-      case 'backButton':
-        return <BackButton />;
-      case 'default':
-        return <Default />;
-      case 'withProfile':
-        return <WithProfile />;
-      default:
-        return <Default />;
-    }
-  };
-
-  return (
-    <header
-      className={cn(
-        'temp-layout fixed left-0 right-0 top-0 z-layout flex h-16 w-full items-center justify-between px-4 py-3',
-        isScrolled ? 'bg-purple-10/[0.94] backdrop-blur-[20px]' : 'bg-transparent'
-      )}
-    >
-      {renderVariant()}
-    </header>
-  );
+const Header = ({ variant = 'default' }: MobileHeaderProps) => {
+  return <Responsive mobile={<MobileHeader variant={variant} />} pc={<PcHeader />} />;
 };
 
 export default Header;

--- a/src/components/layouts/header/mobile-header.tsx
+++ b/src/components/layouts/header/mobile-header.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { cn } from '@/lib/shadcn';
+import { useDetectIsScrolled } from '@/hooks/use-detect-is-scrolled';
+import BackButton from './variants/back-button';
+import Default from './variants/default';
+import WithProfile from './variants/with-profile';
+
+export type MobileHeaderProps = {
+  variant?: 'backButton' | 'default' | 'withProfile';
+};
+
+const MobileHeader = ({ variant = 'default' }: MobileHeaderProps) => {
+  const isScrolled = useDetectIsScrolled();
+
+  const renderVariant = () => {
+    switch (variant) {
+      case 'backButton':
+        return <BackButton />;
+      case 'default':
+        return <Default />;
+      case 'withProfile':
+        return <WithProfile />;
+      default:
+        return <Default />;
+    }
+  };
+
+  return (
+    <header
+      className={cn(
+        'fixed left-0 right-0 top-0 z-layout flex h-16 w-full items-center justify-between px-4 py-3 layout-container',
+        isScrolled ? 'bg-purple-10/[0.94] backdrop-blur-[20px]' : 'bg-transparent'
+      )}
+    >
+      {renderVariant()}
+    </header>
+  );
+};
+
+export default MobileHeader;

--- a/src/components/layouts/header/pc-header.tsx
+++ b/src/components/layouts/header/pc-header.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { cn } from '@/lib/shadcn';
+import { useDetectIsScrolled } from '@/hooks/use-detect-is-scrolled';
+import WithProfile from './variants/with-profile';
+import GlobalNavigationBar from '../global-navigation-bar';
+
+const PcHeader = () => {
+  const isScrolled = useDetectIsScrolled();
+
+  return (
+    <header
+      className={cn(
+        'fixed left-0 right-0 top-0 z-layout h-16 py-3 layout-container',
+        isScrolled ? 'bg-purple-10/[0.94] backdrop-blur-[20px]' : 'bg-transparent'
+      )}
+    >
+      <div className="relative mx-auto flex h-full w-full max-w-[73.75rem] items-center justify-between">
+        <WithProfile />
+        <GlobalNavigationBar className="absolute bottom-auto top-0 h-fit w-fit p-1 xl:grid" />
+      </div>
+    </header>
+  );
+};
+
+export default PcHeader;

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,3 +1,5 @@
+'use client';
+import { isClient, isServer } from '@/utils/predicate.util';
 import { useEffect, useState } from 'react';
 
 const useIsMobile = () => {
@@ -18,4 +20,4 @@ const useIsMobile = () => {
 
 export default useIsMobile;
 
-const isMobile = () => window.innerWidth < 1280;
+const isMobile = () => isClient() && window.innerWidth < 1280;

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,23 +1,25 @@
 'use client';
-import { isClient, isServer } from '@/utils/predicate.util';
+
 import { useEffect, useState } from 'react';
 
 const useIsMobile = () => {
-  const [windowSize, setWindowSize] = useState(isMobile());
+  const [isMobile, setIsMobile] = useState(true);
 
   useEffect(() => {
+    const checkIsMobile = () => window.innerWidth < 1280;
+
+    setIsMobile(checkIsMobile());
+
     const handleResize = () => {
-      setWindowSize(isMobile());
+      setIsMobile(checkIsMobile());
     };
 
-    handleResize();
     window.addEventListener('resize', handleResize);
+
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  return windowSize;
+  return isMobile;
 };
 
 export default useIsMobile;
-
-const isMobile = () => isClient() && window.innerWidth < 1280;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #215

<br>

## 📝 작업 내용

- header와 naviagtion bar의 pc 버전을 구현했습니다.
  - **global navigation bar**에는 단순히 `xl:hidden`을 추가하여 pc에서는 보이지 않도록 했습니다.
  - **header**의 경우에는 pc 버전의 header의 ui는 고정이지만, mobile에서는 변경점이 많아서 서로 다른 컴포넌트로 만들어 처리하였습니다.
  - **useIsMobile**에서 setIsMobile의 초기 값을 계산하면 서버에서도 실행됩니다. 
    - 하지만 서버에서는 window가 없기 때문에 error가 발생함으로 초기값은 false로 주고 클라이언트에서 계산하도록 수정했습니다.
  - **Responsive**의 경우 width 사이즈에 따라 보여주는 ui를 달리하는 컴포넌트 입니다.
    - 이전에 사용했던 부분은 modal로 ui가 바로 보이는 부분이 아니라서 문제가 없었습니다.
    - 하지만 isMobile의 초기값이 무조건 false임으로 desktop에서는 ui가 변경되는 분제가 있었습니다.
    - 따라서 초기에는 간단하게 tailwind를 통해서 관리하는 방식으로 변경하려고 했습니다.
    - 그러나 div안에 값이 들어가게 되면서 ui상의 변경(flex-gap & absolute)이 일어났습니다.
    - 모달에서는 js로 관리하고 ui에 바로 보이는 부분에서는 css로 관리할 수 있도록 **mode**를 만드는 방식으로 해결했습니다.

<br>

## 🖼 스크린샷
![2025-04-242 48 44-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/69a408b5-b67f-46e5-a67d-ee2cf1bdffa3)

<br>

## 💬 리뷰 요구사항

- 리뷰 예상 시간 :`10분`
