### PR TITLE
Refactor/#229 마이페이지 리팩토링

### DIFF
--- a/src/app/(client)/my-page/components/edit-profile-drawer.tsx
+++ b/src/app/(client)/my-page/components/edit-profile-drawer.tsx
@@ -11,9 +11,8 @@ import {
 } from '@/components/ui/drawer';
 import { Typography } from '@/components/ui/typography';
 import EditProfile from './edit-profile';
-import { UserDTO } from '@/types/DTO/user.dto';
 
-const EditProfileDrawer = ({ userInfo }: { userInfo: UserDTO }) => {
+const EditProfileDrawer = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -28,30 +27,28 @@ const EditProfileDrawer = ({ userInfo }: { userInfo: UserDTO }) => {
           <span className="sr-only">프로필 수정하기</span>
         </span>
       </DrawerTrigger>
-      {open && (
-        <DrawerContent className="rounded-t-[2rem] px-5 pt-4">
-          <div className="relative">
-            <DrawerHeader className="p-0 text-left">
-              <DrawerTitle className="py-[0.56rem] pl-1">
-                <Typography as="span" variant="subTitle2" className="py-0">
-                  프로필 수정
-                </Typography>
-              </DrawerTitle>
-              <DrawerDescription className="sr-only">
-                여기에서 프로필을 수정하세요. 완료되면 저장 버튼을 클릭하세요.
-              </DrawerDescription>
-            </DrawerHeader>
-            <EditProfile userInfo={userInfo} setOpen={setOpen} />
-            <DrawerFooter>
-              <DrawerClose className="absolute right-0 top-0">
-                <span className="before:block before:h-10 before:w-10 before:bg-close-line-gray-550-icon before:content-['']">
-                  <span className="sr-only">닫기</span>
-                </span>
-              </DrawerClose>
-            </DrawerFooter>
-          </div>
-        </DrawerContent>
-      )}
+      <DrawerContent className="rounded-t-[2rem] px-5 pt-4">
+        <div className="relative">
+          <DrawerHeader className="p-0 text-left">
+            <DrawerTitle className="py-[0.56rem] pl-1">
+              <Typography as="span" variant="subTitle2" className="py-0">
+                프로필 수정
+              </Typography>
+            </DrawerTitle>
+            <DrawerDescription className="sr-only">
+              여기에서 프로필을 수정하세요. 완료되면 저장 버튼을 클릭하세요.
+            </DrawerDescription>
+          </DrawerHeader>
+          <EditProfile setOpen={setOpen} />
+          <DrawerFooter>
+            <DrawerClose className="absolute right-0 top-0">
+              <span className="before:block before:h-10 before:w-10 before:bg-close-line-gray-550-icon before:content-['']">
+                <span className="sr-only">닫기</span>
+              </span>
+            </DrawerClose>
+          </DrawerFooter>
+        </div>
+      </DrawerContent>
     </Drawer>
   );
 };

--- a/src/app/(client)/my-page/components/edit-profile-drawer.tsx
+++ b/src/app/(client)/my-page/components/edit-profile-drawer.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger
+} from '@/components/ui/drawer';
+import { Typography } from '@/components/ui/typography';
+import EditProfile from './edit-profile';
+import { UserDTO } from '@/types/DTO/user.dto';
+
+const EditProfileDrawer = ({ userInfo }: { userInfo: UserDTO }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <span
+          className="flex h-9 w-9 flex-shrink-0 cursor-pointer items-center justify-center rounded-full bg-white/80 bg-center bg-no-repeat object-contain backdrop-blur-[10px] before:block before:h-4 before:w-4 before:bg-edit-info-icon before:bg-contain before:bg-no-repeat before:content-[''] hover:bg-gray-300/80"
+          aria-label="프로필 수정하기"
+          aria-haspopup="dialog"
+          aria-expanded={open}
+        >
+          <span className="sr-only">프로필 수정하기</span>
+        </span>
+      </DrawerTrigger>
+      {open && (
+        <DrawerContent className="rounded-t-[2rem] px-5 pt-4">
+          <div className="relative">
+            <DrawerHeader className="p-0 text-left">
+              <DrawerTitle className="py-[0.56rem] pl-1">
+                <Typography as="span" variant="subTitle2" className="py-0">
+                  프로필 수정
+                </Typography>
+              </DrawerTitle>
+              <DrawerDescription className="sr-only">
+                여기에서 프로필을 수정하세요. 완료되면 저장 버튼을 클릭하세요.
+              </DrawerDescription>
+            </DrawerHeader>
+            <EditProfile userInfo={userInfo} setOpen={setOpen} />
+            <DrawerFooter>
+              <DrawerClose className="absolute right-0 top-0">
+                <span className="before:block before:h-10 before:w-10 before:bg-close-line-gray-550-icon before:content-['']">
+                  <span className="sr-only">닫기</span>
+                </span>
+              </DrawerClose>
+            </DrawerFooter>
+          </div>
+        </DrawerContent>
+      )}
+    </Drawer>
+  );
+};
+
+export default EditProfileDrawer;

--- a/src/app/(client)/my-page/components/edit-profile.tsx
+++ b/src/app/(client)/my-page/components/edit-profile.tsx
@@ -10,7 +10,6 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import formSchema from '@/app/schemas/form-schema.schema';
-import { UserDTO } from '@/types/DTO/user.dto';
 import { cleanupBlobUrl } from '@/utils/cleanup-blob-url.util';
 import IconButton from '@/components/commons/icon-button';
 import { Typography } from '@/components/ui/typography';
@@ -26,23 +25,22 @@ const editProfileFormSchema = z.object({
 type FormValues = z.infer<typeof editProfileFormSchema>;
 
 type EditProfileProps = {
-  userInfo: UserDTO;
   setOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-const EditProfile = ({ userInfo, setOpen }: EditProfileProps) => {
-  const setUser = useUserStore((state) => state.setUser);
+const EditProfile = ({ setOpen }: EditProfileProps) => {
+  const { user, setUser } = useUserStore();
 
   const [profileState, setProfileState] = useState({
     isUploading: false,
-    profilePreviewUrl: userInfo?.profileImage || null
+    profilePreviewUrl: user?.profileImage || null
   });
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(editProfileFormSchema),
     defaultValues: {
-      nickname: userInfo.nickname || '',
+      nickname: user.nickname || '',
       newProfileImage: null
     }
   });
@@ -91,7 +89,7 @@ const EditProfile = ({ userInfo, setOpen }: EditProfileProps) => {
       }
     }
 
-    if (formData.nickname === userInfo.nickname && profilePreviewUrl === userInfo.profileImage) {
+    if (formData.nickname === user.nickname && profilePreviewUrl === user.profileImage) {
       alert('변경된 정보가 없습니다.');
       return setIsUploading(false);
     }

--- a/src/app/(client)/my-page/components/profile-bar.tsx
+++ b/src/app/(client)/my-page/components/profile-bar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Typography } from '@/components/ui/typography';
-import { useEffect, useState } from 'react';
 import { HorizontalSkeleton } from '@/components/commons/horizontal-skeleton';
 import { useUserStore } from '@/store/user-store';
 import ProfileImage from '@/components/commons/profile-image';
@@ -9,12 +8,7 @@ import EditProfileDrawer from './edit-profile-drawer';
 
 const ProfileBar = () => {
   const user = useUserStore((state) => state.user);
-  const isDataLoaded = !!user;
-  const [isProfileImageLoading, setIsProfileImageLoading] = useState(true);
-
-  useEffect(() => {
-    setIsProfileImageLoading(true);
-  }, [user.profileImage]);
+  const isDataLoaded = !!user.id;
 
   return (
     <div className="flex items-center justify-between gap-2 px-4 pb-4 pt-1">
@@ -22,12 +16,7 @@ const ProfileBar = () => {
         <>
           <div className="flex w-full items-center gap-3">
             <div className="relative aspect-square w-[4.5rem] overflow-hidden rounded-full">
-              <ProfileImage
-                src={user.profileImage}
-                size="md"
-                isImageLoading={isProfileImageLoading}
-                setIsImageLoading={setIsProfileImageLoading}
-              />
+              <ProfileImage src={user.profileImage} size="md" />
             </div>
             <div className="flex flex-1 flex-col">
               <Typography as="span" variant="subTitle1">
@@ -39,7 +28,7 @@ const ProfileBar = () => {
             </div>
           </div>
           {/* 프로필 수정 Drawer */}
-          <EditProfileDrawer userInfo={user} />
+          <EditProfileDrawer />
         </>
       ) : (
         <div className="flex min-h-[4.5rem] items-center">

--- a/src/app/(client)/my-page/components/profile-bar.tsx
+++ b/src/app/(client)/my-page/components/profile-bar.tsx
@@ -1,34 +1,19 @@
 'use client';
 
 import { Typography } from '@/components/ui/typography';
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger
-} from '@/components/ui/drawer';
 import { useEffect, useState } from 'react';
 import { HorizontalSkeleton } from '@/components/commons/horizontal-skeleton';
 import { useUserStore } from '@/store/user-store';
-import EditProfile from '@/app/(client)/my-page/components/edit-profile';
 import ProfileImage from '@/components/commons/profile-image';
+import EditProfileDrawer from './edit-profile-drawer';
 
 const ProfileBar = () => {
   const user = useUserStore((state) => state.user);
-  const [open, setOpen] = useState(false);
-  const [isDataLoaded, setIsDataLoaded] = useState(false);
-  const [isImageLoading, setIsImageLoading] = useState(true);
+  const isDataLoaded = !!user;
+  const [isProfileImageLoading, setIsProfileImageLoading] = useState(true);
 
   useEffect(() => {
-    if (user.id) setIsDataLoaded(!!user.id);
-  }, [user]);
-
-  useEffect(() => {
-    setIsImageLoading(true);
+    setIsProfileImageLoading(true);
   }, [user.profileImage]);
 
   return (
@@ -40,8 +25,8 @@ const ProfileBar = () => {
               <ProfileImage
                 src={user.profileImage}
                 size="md"
-                isImageLoading={isImageLoading}
-                setIsImageLoading={setIsImageLoading}
+                isImageLoading={isProfileImageLoading}
+                setIsImageLoading={setIsProfileImageLoading}
               />
             </div>
             <div className="flex flex-1 flex-col">
@@ -53,43 +38,8 @@ const ProfileBar = () => {
               </Typography>
             </div>
           </div>
-
-          <Drawer open={open} onOpenChange={setOpen}>
-            <DrawerTrigger asChild>
-              <span
-                className="flex h-9 w-9 flex-shrink-0 cursor-pointer items-center justify-center rounded-full bg-white/80 bg-center bg-no-repeat object-contain backdrop-blur-[10px] before:block before:h-4 before:w-4 before:bg-edit-info-icon before:bg-contain before:bg-no-repeat before:content-[''] hover:bg-gray-300/80"
-                aria-label="프로필 수정하기"
-                aria-haspopup="dialog"
-                aria-expanded={open}
-              >
-                <span className="sr-only">프로필 수정하기</span>
-              </span>
-            </DrawerTrigger>
-            {open && (
-              <DrawerContent className="rounded-t-[2rem] px-5 pt-4">
-                <div className="relative">
-                  <DrawerHeader className="p-0 text-left">
-                    <DrawerTitle className="py-[0.56rem] pl-1">
-                      <Typography as="span" variant="subTitle2" className="py-0">
-                        프로필 수정
-                      </Typography>
-                    </DrawerTitle>
-                    <DrawerDescription className="sr-only">
-                      여기에서 프로필을 수정하세요. 완료되면 저장 버튼을 클릭하세요.
-                    </DrawerDescription>
-                  </DrawerHeader>
-                  <EditProfile userInfo={user} setOpen={setOpen} />
-                  <DrawerFooter>
-                    <DrawerClose className="absolute right-0 top-0">
-                      <span className="before:block before:h-10 before:w-10 before:bg-close-line-gray-550-icon before:content-['']">
-                        <span className="sr-only">닫기</span>
-                      </span>
-                    </DrawerClose>
-                  </DrawerFooter>
-                </div>
-              </DrawerContent>
-            )}
-          </Drawer>
+          {/* 프로필 수정 Drawer */}
+          <EditProfileDrawer userInfo={user} />
         </>
       ) : (
         <div className="flex min-h-[4.5rem] items-center">

--- a/src/app/(client)/my-page/components/user-goal-card.tsx
+++ b/src/app/(client)/my-page/components/user-goal-card.tsx
@@ -3,48 +3,18 @@ import ButtonLink from '@/components/commons/button-link';
 import { Typography } from '@/components/ui/typography';
 import SITE_MAP from '@/constants/site-map.constant';
 import { NUTRITION_PURPOSE_OPTIONS } from '@/constants/user-personal-info.constant';
-import { getPercentage } from '@/utils/nutrition-calculator.util';
-import { UserDTO } from '@/types/DTO/user.dto';
+import { UserPersonalInfoDTO } from '@/types/DTO/user.dto';
 import MacronutrientCard from './macronutrient-card';
 import { formatNumberWithComma } from '@/utils/format.util';
+import { calculateMacronutrientRatio } from '../utils/calculate-macronutrient-ratio';
 
 type UserGoalCardProps = {
-  userInfo: UserDTO;
-};
-
-const NUTRITION_PURPOSE_OPTIONS_IN_PROFILE = {
-  ...NUTRITION_PURPOSE_OPTIONS,
-  NOT_SET: {
-    name: '미설정',
-    factor: 0,
-    ratio: {
-      carbohydrate: 0,
-      protein: 0,
-      fat: 0
-    }
-  }
+  userInfo: UserPersonalInfoDTO | null;
 };
 
 const UserGoalCard = ({ userInfo }: UserGoalCardProps) => {
-  const {
-    purpose = 'NOT_SET',
-    dailyCaloriesGoal = 0,
-    dailyProteinGoal = 0,
-    dailyCarbohydrateGoal = 0,
-    dailyFatGoal = 0
-  } = userInfo.personalInfo ?? {};
-
-  const calculateMacroRatio = () => {
-    const total = dailyCarbohydrateGoal + dailyProteinGoal + dailyFatGoal;
-
-    if (total === 0) return '0 : 0 : 0';
-
-    const carbRatio = getPercentage(dailyCarbohydrateGoal, total);
-    const proteinRatio = getPercentage(dailyProteinGoal, total);
-    const fatRatio = getPercentage(dailyFatGoal, total);
-
-    return `${carbRatio} : ${proteinRatio} : ${fatRatio}`;
-  };
+  const { purpose, dailyCaloriesGoal, dailyProteinGoal, dailyCarbohydrateGoal, dailyFatGoal } =
+    userInfo ?? defaultUserInfo;
 
   return (
     <div className="flex flex-col rounded-2xl bg-white px-4 py-3">
@@ -58,9 +28,15 @@ const UserGoalCard = ({ userInfo }: UserGoalCardProps) => {
       </div>
       <div className="pt-3">
         <ul className="flex flex-col gap-2">
-          <UserInfoList title="건강 목표" description={NUTRITION_PURPOSE_OPTIONS_IN_PROFILE[purpose].name} />
+          <UserInfoList
+            title="건강 목표"
+            description={NUTRITION_PURPOSE_OPTIONS_IN_PROFILE[purpose as NutritionPurposeKey].name}
+          />
           <UserInfoList title="1일 목표 칼로리" description={`${formatNumberWithComma(dailyCaloriesGoal)} kcal`} />
-          <UserInfoList title="목표 기준 탄단지 비율" description={calculateMacroRatio()} />
+          <UserInfoList
+            title="목표 기준 탄단지 비율"
+            description={calculateMacronutrientRatio(dailyCarbohydrateGoal, dailyProteinGoal, dailyFatGoal)}
+          />
         </ul>
         <MacronutrientCard
           dailyProteinGoal={dailyProteinGoal}
@@ -73,3 +49,26 @@ const UserGoalCard = ({ userInfo }: UserGoalCardProps) => {
 };
 
 export default UserGoalCard;
+
+const defaultUserInfo = {
+  purpose: 'NOT_SET',
+  dailyCaloriesGoal: 0,
+  dailyProteinGoal: 0,
+  dailyCarbohydrateGoal: 0,
+  dailyFatGoal: 0
+};
+
+type NutritionPurposeKey = keyof typeof NUTRITION_PURPOSE_OPTIONS | 'NOT_SET';
+
+const NUTRITION_PURPOSE_OPTIONS_IN_PROFILE = {
+  ...NUTRITION_PURPOSE_OPTIONS,
+  NOT_SET: {
+    name: '미설정',
+    factor: 0,
+    ratio: {
+      carbohydrate: 0,
+      protein: 0,
+      fat: 0
+    }
+  }
+};

--- a/src/app/(client)/my-page/page.tsx
+++ b/src/app/(client)/my-page/page.tsx
@@ -20,7 +20,7 @@ const MyPage = async () => {
             description="1일 목표 칼로리를 설정하고 식사를 기록하면 1일 권장 섭취량과 나에게 딱 맞는 식단 피드백을 받을 수 있어요!"
           />
         )}
-        <UserGoalCard userInfo={userInfo} />
+        <UserGoalCard userInfo={userInfo.personalInfo} />
         <UserPhysicalInfoCard userInfo={userInfo} />
         <SettingCard />
       </GlassBackground>

--- a/src/app/(client)/my-page/utils/calculate-macronutrient-ratio.ts
+++ b/src/app/(client)/my-page/utils/calculate-macronutrient-ratio.ts
@@ -1,0 +1,17 @@
+import { getPercentage } from '@/utils/nutrition-calculator.util';
+
+export const calculateMacronutrientRatio = (
+  dailyCarbohydrateGoal: number,
+  dailyProteinGoal: number,
+  dailyFatGoal: number
+) => {
+  const total = dailyCarbohydrateGoal + dailyProteinGoal + dailyFatGoal;
+
+  if (total === 0) return '0 : 0 : 0';
+
+  const carbRatio = getPercentage(dailyCarbohydrateGoal, total);
+  const proteinRatio = getPercentage(dailyProteinGoal, total);
+  const fatRatio = getPercentage(dailyFatGoal, total);
+
+  return `${carbRatio} : ${proteinRatio} : ${fatRatio}`;
+};

--- a/src/app/(client)/my-page/utils/upload-profile-image.ts
+++ b/src/app/(client)/my-page/utils/upload-profile-image.ts
@@ -1,0 +1,15 @@
+import { uploadImage } from '@/apis/storage.api';
+import { SupabaseBucket } from '@/types/supabase-bucket.type';
+
+export const uploadProfileImage = async (imageFile: File): Promise<string> => {
+  const uploadForm = new FormData();
+  uploadForm.append('file', imageFile);
+
+  const result = await uploadImage(SupabaseBucket.PROFILE_IMAGES, uploadForm);
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data;
+};

--- a/src/components/commons/profile-image.tsx
+++ b/src/components/commons/profile-image.tsx
@@ -2,6 +2,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import DEFAULT_PROFILE from '@/../public/illustrations/default-profile.svg';
 import Image from 'next/image';
 import { cn } from '@/lib/shadcn';
+import { useEffect, useState } from 'react';
 
 const profileImageVariants = cva('relative overflow-hidden rounded-full', {
   variants: {
@@ -22,8 +23,27 @@ type ProfileImageProps = VariantProps<typeof profileImageVariants> & {
   setIsImageLoading?: (isLoading: boolean) => void;
 };
 
-const ProfileImage = ({ src, size, isImageLoading, setIsImageLoading }: ProfileImageProps) => {
+const ProfileImage = ({
+  src,
+  size,
+  isImageLoading: externalIsLoading,
+  setIsImageLoading: externalSetIsLoading
+}: ProfileImageProps) => {
+  const [internalIsLoading, setInternalIsLoading] = useState(true);
+  const isControlled = externalIsLoading !== undefined && externalSetIsLoading !== undefined;
+  const isImageLoading = isControlled ? externalIsLoading : internalIsLoading;
+  const setIsImageLoading = isControlled ? externalSetIsLoading : setInternalIsLoading;
+
   const imageUrl = src || DEFAULT_PROFILE;
+
+  useEffect(() => {
+    setIsImageLoading(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [src]);
+
+  const handleImageLoad = () => {
+    setIsImageLoading(false);
+  };
 
   return (
     <div className={profileImageVariants({ size })}>
@@ -35,7 +55,7 @@ const ProfileImage = ({ src, size, isImageLoading, setIsImageLoading }: ProfileI
         sizes="20vw"
         priority
         key={imageUrl}
-        onLoad={() => setIsImageLoading?.(false)}
+        onLoad={handleImageLoad}
       />
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #229 

<br>

## 📝 작업 내용

- `userGoalCard` props 수정
- `calculateMacroRatio` 유틸 함수 분리
- 구조 분해 할당으로 받아올 수 있는 값 수정
- 불필요한 useState, useEffect 삭제
- defaultUserInfo 적용 방식 변경
- 기존 컨벤션에 맞춰 컴포넌트의 반환 타입 삭제

<br>

## 💬 리뷰 요구사항

> - 리뷰 예상 시간 : `15분`
> - 재상튜터님의 리뷰를 받고 나니.. 뭔가 어떤 것을 상태로 관리할 것인가와 언제 구조분해할당을 받아야 할지 딱 삘이 왔어요..! 유레카


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 프로필 수정용 드로어 UI가 추가되어 프로필을 쉽게 수정할 수 있습니다.
    - 프로필 이미지 업로드 기능이 개선되어 오류 처리 및 사용자 알림이 향상되었습니다.
    - 영양 목표의 탄단지 비율을 자동 계산하여 보기 쉽게 표시합니다.

- **Bug Fixes**
    - 프로필 데이터 변경이 없을 때 저장이 차단되고 알림이 제공됩니다.

- **Refactor**
    - 프로필 수정 및 목표 카드 컴포넌트의 데이터 구조와 상태 관리가 간소화되고 명확해졌습니다.
    - 영양 목표 카드가 개인 정보만을 받도록 개선되었습니다.
    - 프로필바 컴포넌트에서 프로필 수정 UI가 별도 드로어 컴포넌트로 분리되어 구조가 단순해졌습니다.
    - 프로필 이미지 컴포넌트가 로딩 상태를 내부 또는 외부에서 제어할 수 있도록 개선되었습니다.

- **Chores**
    - 불필요한 코드와 사용하지 않는 import가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->