### PR TITLE
Refactor/#235 목표 설정 리팩토링

### DIFF
--- a/src/app/(client)/set-goal/components/set-goal-funnel.tsx
+++ b/src/app/(client)/set-goal/components/set-goal-funnel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
+import { Suspense } from 'react';
 import { z } from 'zod';
 import useFunnel from '@/hooks/use-funnel';
 import { ActivityLevelType, GenderType, PurposeType } from '@/types/user-personal-info.type';
@@ -24,9 +24,43 @@ import {
   StepWeightType
 } from '../types/funnel.type';
 import { userPhysicalProfileSchema } from '../schemas/user-physical-profile.schema';
+import useScrollToTop from '../hooks/use-scroll-to-top';
 
-type SetGoalFunnelProps = {
-  userName: string;
+const SetGoalFunnel = () => {
+  const { Funnel } = useFunnel<validateStep, FunnelStep>('step1', validateFn, 'session-key');
+  useScrollToTop();
+
+  return (
+    <Suspense>
+      <Funnel
+        step1={({ setStep }) => <PurposeStep nextStep={(purpose: PurposeType) => setStep('step2', { purpose })} />}
+        step2={({ setStep }) => <GenderStep nextStep={(gender: GenderType) => setStep('step3', { gender })} />}
+        step3={({ setStep }) => <AgeStep nextStep={(age: number) => setStep('step4', { age })} />}
+        step4={({ setStep }) => <HeightStep nextStep={(height: number) => setStep('step5', { height })} />}
+        step5={({ setStep }) => <WeightStep nextStep={(weight: number) => setStep('step6', { weight })} />}
+        step6={({ setStep }) => (
+          <ActivityLevelStep nextStep={(data: ActivityLevelType) => setStep('step7', { activityLevel: data })} />
+        )}
+        step7={({ setStep }) => <StepAiLoading nextStep={() => setStep('step8')} />}
+        step8={({ setStep, data }) => <CalculateStep data={data} nextStep={setStep} />}
+        complete={() => <Complete />}
+      />
+    </Suspense>
+  );
+};
+
+export default SetGoalFunnel;
+
+type validateStep = {
+  step1: StepPurposeType;
+  step2: StepGenderType;
+  step3: StepAgeType;
+  step4: StepHeightType;
+  step5: StepWeightType;
+  step6: StepActivityLevelType;
+  step7: StepCompleteType;
+  step8: StepCompleteType;
+  complete: StepCompleteType;
 };
 
 const validateStep = {
@@ -41,68 +75,14 @@ const validateStep = {
   complete: userPhysicalProfileSchema
 };
 
-const SetGoalFunnel = ({ userName }: SetGoalFunnelProps) => {
-  const { Funnel, currentStep } = useFunnel<
-    {
-      step1: StepPurposeType;
-      step2: StepGenderType;
-      step3: StepAgeType;
-      step4: StepHeightType;
-      step5: StepWeightType;
-      step6: StepActivityLevelType;
-      step7: StepCompleteType;
-      step8: StepCompleteType;
-      complete: StepCompleteType;
-    },
-    FunnelStep
-  >(
-    'step1',
-    {
-      step1: () => true,
-      step2: (data) => validateStep.step2.safeParse(data).success,
-      step3: (data) => validateStep.step3.safeParse(data).success,
-      step4: (data) => validateStep.step4.safeParse(data).success,
-      step5: (data) => validateStep.step5.safeParse(data).success,
-      step6: (data) => validateStep.step6.safeParse(data).success,
-      step7: (data) => validateStep.step7.safeParse(data).success,
-      step8: () => true,
-      complete: (data) => validateStep.complete.safeParse(data).success
-    },
-    'session-key'
-  );
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [currentStep]);
-
-  return (
-    <Suspense>
-      <Funnel
-        step1={({ setStep }) => (
-          <PurposeStep userName={userName} nextStep={(purpose: PurposeType) => setStep('step2', { purpose })} />
-        )}
-        step2={({ setStep }) => (
-          <GenderStep userName={userName} nextStep={(gender: GenderType) => setStep('step3', { gender })} />
-        )}
-        step3={({ setStep }) => <AgeStep userName={userName} nextStep={(age: number) => setStep('step4', { age })} />}
-        step4={({ setStep }) => (
-          <HeightStep userName={userName} nextStep={(height: number) => setStep('step5', { height })} />
-        )}
-        step5={({ setStep }) => (
-          <WeightStep userName={userName} nextStep={(weight: number) => setStep('step6', { weight })} />
-        )}
-        step6={({ setStep }) => (
-          <ActivityLevelStep
-            userName={userName}
-            nextStep={(data: ActivityLevelType) => setStep('step7', { activityLevel: data })}
-          />
-        )}
-        step7={({ setStep }) => <StepAiLoading nextStep={() => setStep('step8')} />}
-        step8={({ setStep, data }) => <CalculateStep userName={userName} data={data} nextStep={setStep} />}
-        complete={() => <Complete userName={userName} />}
-      />
-    </Suspense>
-  );
+const validateFn = {
+  step1: () => true,
+  step2: (data: StepPurposeType) => validateStep.step2.safeParse(data).success,
+  step3: (data: StepGenderType) => validateStep.step3.safeParse(data).success,
+  step4: (data: StepAgeType) => validateStep.step4.safeParse(data).success,
+  step5: (data: StepHeightType) => validateStep.step5.safeParse(data).success,
+  step6: (data: StepWeightType) => validateStep.step6.safeParse(data).success,
+  step7: (data: StepActivityLevelType) => validateStep.step7.safeParse(data).success,
+  step8: () => true,
+  complete: (data: StepCompleteType) => validateStep.complete.safeParse(data).success
 };
-
-export default SetGoalFunnel;

--- a/src/app/(client)/set-goal/components/step-activity-level.tsx
+++ b/src/app/(client)/set-goal/components/step-activity-level.tsx
@@ -4,12 +4,13 @@ import { Button } from '@/components/ui/button';
 import { Typography } from '@/components/ui/typography';
 import { ActivityLevelType } from '@/types/user-personal-info.type';
 import { GOAL_OPTIONS } from '../constants/funnel.constant';
+import { useUserStore } from '@/store/user-store';
 
 type StepActivityLevelProps = {
-  userName: string;
   nextStep: (data: ActivityLevelType) => void;
 };
-const StepActivityLevel = ({ userName, nextStep }: StepActivityLevelProps) => {
+const StepActivityLevel = ({ nextStep }: StepActivityLevelProps) => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   const [selectedOption, setSelectedOption] = useState<ActivityLevelType | null>(null);
 
   const handleSelectOption = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/(client)/set-goal/components/step-age.tsx
+++ b/src/app/(client)/set-goal/components/step-age.tsx
@@ -6,9 +6,9 @@ import formSchema from '@/app/schemas/form-schema.schema';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useUserStore } from '@/store/user-store';
 
 type StepAgeProps = {
-  userName: string;
   nextStep: (data: number) => void;
 };
 
@@ -18,7 +18,8 @@ const ageFormSchema = z.object({
 
 type FormValues = z.infer<typeof ageFormSchema>;
 
-const StepAge = ({ userName, nextStep }: StepAgeProps) => {
+const StepAge = ({ nextStep }: StepAgeProps) => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   const form = useForm<FormValues>({
     resolver: zodResolver(ageFormSchema),
     defaultValues: {

--- a/src/app/(client)/set-goal/components/step-ai-loading.tsx
+++ b/src/app/(client)/set-goal/components/step-ai-loading.tsx
@@ -14,7 +14,7 @@ const StepAiLoading = ({ nextStep }: StepAiLoadingProps) => {
   useEffect(() => {
     const timeout = setTimeout(() => {
       nextStep();
-    }, 3000);
+    }, 2000);
     return () => {
       clearTimeout(timeout);
     };

--- a/src/app/(client)/set-goal/components/step-complete.tsx
+++ b/src/app/(client)/set-goal/components/step-complete.tsx
@@ -2,12 +2,10 @@ import { Button } from '@/components/ui/button';
 import { Typography } from '@/components/ui/typography';
 import SITE_MAP from '@/constants/site-map.constant';
 import Link from 'next/link';
+import { useUserStore } from '@/store/user-store';
 
-type StepCompleteProps = {
-  userName: string;
-};
-
-const StepComplete = ({ userName }: StepCompleteProps) => {
+const StepComplete = () => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   return (
     <div className="absolute left-1/2 top-1/2 flex w-full -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-3 before:mb-5 before:h-20 before:w-20 before:bg-complete-confetti before:bg-contain before:content-['']">
       <Typography as="h3" variant="title3">

--- a/src/app/(client)/set-goal/components/step-gender.tsx
+++ b/src/app/(client)/set-goal/components/step-gender.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { Typography } from '@/components/ui/typography';
 import { GenderType } from '@/types/user-personal-info.type';
 import { GOAL_OPTIONS } from '../constants/funnel.constant';
+import { useUserStore } from '@/store/user-store';
 
 type StepGenderProps = {
-  userName: string;
   nextStep: (data: GenderType) => void;
 };
-const StepGender = ({ userName, nextStep }: StepGenderProps) => {
+
+const StepGender = ({ nextStep }: StepGenderProps) => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   const [selectedOption, setSelectedOption] = useState<GenderType | null>(null);
 
   const handleSelectOption = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/(client)/set-goal/components/step-height.tsx
+++ b/src/app/(client)/set-goal/components/step-height.tsx
@@ -6,9 +6,9 @@ import formSchema from '@/app/schemas/form-schema.schema';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useUserStore } from '@/store/user-store';
 
 type StepHeightProps = {
-  userName: string;
   nextStep: (data: number) => void;
 };
 
@@ -18,7 +18,8 @@ const heightFormSchema = z.object({
 
 type FormValues = z.infer<typeof heightFormSchema>;
 
-const StepHeight = ({ userName, nextStep }: StepHeightProps) => {
+const StepHeight = ({ nextStep }: StepHeightProps) => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   const form = useForm<FormValues>({
     resolver: zodResolver(heightFormSchema),
     defaultValues: {

--- a/src/app/(client)/set-goal/components/step-purpose.tsx
+++ b/src/app/(client)/set-goal/components/step-purpose.tsx
@@ -4,13 +4,14 @@ import { Typography } from '@/components/ui/typography';
 import { PurposeType } from '@/types/user-personal-info.type';
 import { ChangeEvent, FormEvent, useState } from 'react';
 import { GOAL_OPTIONS } from '../constants/funnel.constant';
+import { useUserStore } from '@/store/user-store';
 
 type StepPurposeProps = {
-  userName: string;
   nextStep: (data: PurposeType) => void;
 };
 
-const StepPurpose = ({ userName, nextStep }: StepPurposeProps) => {
+const StepPurpose = ({ nextStep }: StepPurposeProps) => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   const [selectedOption, setSelectedOption] = useState<PurposeType | null>(null);
 
   const handleSelectOption = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/app/(client)/set-goal/components/step-weight.tsx
+++ b/src/app/(client)/set-goal/components/step-weight.tsx
@@ -6,9 +6,9 @@ import formSchema from '@/app/schemas/form-schema.schema';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useUserStore } from '@/store/user-store';
 
 type StepWeightProps = {
-  userName: string;
   nextStep: (data: number) => void;
 };
 
@@ -18,7 +18,8 @@ const weightFormSchema = z.object({
 
 type FormValues = z.infer<typeof weightFormSchema>;
 
-const StepWeight = ({ userName, nextStep }: StepWeightProps) => {
+const StepWeight = ({ nextStep }: StepWeightProps) => {
+  const { nickname: userName } = useUserStore((state) => state.user);
   const form = useForm<FormValues>({
     resolver: zodResolver(weightFormSchema),
     defaultValues: {

--- a/src/app/(client)/set-goal/hooks/use-client-calculation.ts
+++ b/src/app/(client)/set-goal/hooks/use-client-calculation.ts
@@ -1,0 +1,26 @@
+import { userPhysicalProfileSchema } from '../schemas/user-physical-profile.schema';
+import { calculateDailyNutritionGoal } from '@/utils/nutrition-calculator.util';
+import { StepCompleteType } from '../types/funnel.type';
+import { UpdateUserPersonalGoalDTO } from '@/types/DTO/user.dto';
+import useIsClient from '@/hooks/use-is-client';
+
+const initialUserPersonalGoal: UpdateUserPersonalGoalDTO = {
+  dailyCaloriesGoal: 0,
+  dailyCarbohydrateGoal: 0,
+  dailyProteinGoal: 0,
+  dailyFatGoal: 0
+};
+
+export const useClientCalculation = (data: StepCompleteType) => {
+  const isClient = useIsClient();
+  let userPersonalGoal = initialUserPersonalGoal;
+
+  if (isClient) {
+    const parseResult = userPhysicalProfileSchema.safeParse(data);
+    if (parseResult.success) {
+      userPersonalGoal = calculateDailyNutritionGoal(parseResult.data);
+    }
+  }
+
+  return userPersonalGoal;
+};

--- a/src/app/(client)/set-goal/hooks/use-scroll-to-top.ts
+++ b/src/app/(client)/set-goal/hooks/use-scroll-to-top.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+const useScrollToTop = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+};
+
+export default useScrollToTop;

--- a/src/app/(client)/set-goal/page.tsx
+++ b/src/app/(client)/set-goal/page.tsx
@@ -3,24 +3,22 @@
 import GlassBackground from '@/components/commons/glass-background';
 import { useSearchParams } from 'next/navigation';
 import { getPercentage } from '@/utils/nutrition-calculator.util';
-import { useUserStore } from '@/store/user-store';
 import SetGoalFunnel from './components/set-goal-funnel';
 import { LAST_STEP_FOR_USER_INPUT, STEP_UI_CONFIG } from './constants/funnel.constant';
 import { FunnelStep } from './types/funnel.type';
 import FunnelProgressSection from '@/components/commons/funnel-progress-section';
 
 const SetGoalPage = () => {
-  const user = useUserStore((state) => state.user);
   const params = useSearchParams();
   const currentStep = (params.get('step') || 'step1') as FunnelStep;
 
-  const currentOrder = STEP_UI_CONFIG[currentStep].stepOrder;
-  const progressPercent = Math.min(getPercentage(currentOrder, LAST_STEP_FOR_USER_INPUT), 100);
+  const { stepOrder: currentOrder } = STEP_UI_CONFIG[currentStep];
+  const progressPercent = getPercentage(currentOrder, LAST_STEP_FOR_USER_INPUT);
 
-  const currentUIConfig = STEP_UI_CONFIG[currentStep];
+  const { hasProgressBar, hasGlassBackground } = STEP_UI_CONFIG[currentStep];
 
   const renderProgressBar = () => {
-    if (!currentUIConfig.hasProgressBar) return null;
+    if (!hasProgressBar) return null;
 
     return <FunnelProgressSection title="목표 설정하기" percent={progressPercent} />;
   };
@@ -28,11 +26,11 @@ const SetGoalPage = () => {
   const content = (
     <>
       {renderProgressBar()}
-      <SetGoalFunnel userName={user.nickname} />
+      <SetGoalFunnel />
     </>
   );
 
-  if (currentUIConfig.hasGlassBackground) {
+  if (hasGlassBackground) {
     return (
       <GlassBackground className="relative space-y-8 xl:min-h-fit xl:rounded-[2rem] xl:p-6">{content}</GlassBackground>
     );

--- a/src/app/(client)/set-goal/utils/calculate-macronutrient-data.ts.ts
+++ b/src/app/(client)/set-goal/utils/calculate-macronutrient-data.ts.ts
@@ -1,0 +1,26 @@
+import { UpdateUserPersonalInfoDTO } from '@/types/DTO/user.dto';
+import { getPercentage } from '@/utils/nutrition-calculator.util';
+
+const calculateMacronutrientData = (userPersonalInfos: UpdateUserPersonalInfoDTO) => {
+  const totalMacros =
+    userPersonalInfos.dailyCarbohydrateGoal + userPersonalInfos.dailyProteinGoal + userPersonalInfos.dailyFatGoal;
+
+  const macronutrientData = {
+    carbohydrate: {
+      grams: userPersonalInfos.dailyCarbohydrateGoal,
+      percentage: getPercentage(userPersonalInfos.dailyCarbohydrateGoal, totalMacros)
+    },
+    protein: {
+      grams: userPersonalInfos.dailyProteinGoal,
+      percentage: getPercentage(userPersonalInfos.dailyProteinGoal, totalMacros)
+    },
+    fat: {
+      grams: userPersonalInfos.dailyFatGoal,
+      percentage: getPercentage(userPersonalInfos.dailyFatGoal, totalMacros)
+    }
+  };
+
+  return macronutrientData;
+};
+
+export default calculateMacronutrientData;

--- a/src/hooks/use-funnel.tsx
+++ b/src/hooks/use-funnel.tsx
@@ -65,7 +65,6 @@ type FunnelComponentProps<K extends Record<string, unknown>, T extends Extract<k
  */
 type UseFunnelReturnType<K extends Record<string, unknown>, T extends Extract<keyof K, string>> = {
   Funnel: (props: FunnelComponentProps<K, T>) => JSX.Element;
-  currentStep: T;
 };
 
 /**
@@ -163,7 +162,7 @@ const useFunnel = <K extends Record<string, unknown>, T extends Extract<keyof K,
     return props[currentStep]({ setStep, data: funnelDataRef.current as K[T], clearFunnelData });
   };
 
-  return { Funnel, currentStep };
+  return { Funnel };
 };
 
 export default useFunnel;

--- a/src/types/DTO/user.dto.ts
+++ b/src/types/DTO/user.dto.ts
@@ -37,6 +37,10 @@ export type UserSignInDTO = Pick<UserDTO, 'email'> & { password: string };
 
 export type UpdateUserDTO = Omit<UserDTO, 'id' | 'createdAt' | 'email'>;
 export type UpdateUserPersonalInfoDTO = Omit<UserPersonalInfoDTO, 'id' | 'userId'>;
+export type UpdateUserPersonalGoalDTO = Pick<
+  UserPersonalInfoDTO,
+  'dailyCaloriesGoal' | 'dailyCarbohydrateGoal' | 'dailyProteinGoal' | 'dailyFatGoal'
+>;
 
 export type SupabaseAuthDTO = {
   user: User | null;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #235

<br>

## 📝 작업 내용

- _재상 튜터님의 코드 리뷰 반영 내용입니다._
- props로 내려주던 유저의 정보를 **스토어에서 직접 사용**하도록 했습니다.
  - 스토어에 있는 걸 왜 내려줬나 싶었는데 초기 구현에서는 유저 정보 자체를 서버액션으로 불러왔어서 로직이 그대로 간 것 같아요
- 목표 설정 퍼널의 **스텝 타입과 검증 함수를 개별 선언**해 코드 간결화
- ai 계산 로딩 **2초**로 단축
- 스크롤 초기화와 클라이언트단에서 계산되어야 하는 로직을 **커스텀 훅**으로 변경
- **구조분해할당**이 가능한 부분 반영

<br>

## 💬 리뷰 요구사항

> - 리뷰 예상 시간 : `10분`
> - 재상님이 리뷰해주셨던 내용 녹화 따둔 것 확인하며 반영했습니다! 그럼에도 혹시 호오옥시나 제가 빠뜨린 내용이 있다면 말씀 부탁드립니다.. 😱


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 사용자 이름(`userName`) 전달 방식을 전역 상태 관리(store)에서 직접 조회하도록 변경하여 여러 목표 설정 단계 컴포넌트에서 prop 전달을 제거했습니다.
  - 목표 설정 퍼널 및 각 단계 컴포넌트의 props와 내부 구조를 간소화했습니다.
  - 퍼널 단계 유효성 검증 및 계산 로직을 별도의 훅과 유틸리티 함수로 분리하여 코드 구조를 개선했습니다.

- **New Features**
  - 영양 목표 계산을 위한 커스텀 훅과 매크로 영양소 데이터 계산 유틸리티가 추가되었습니다.
  - 페이지 진입 시 자동 스크롤을 위한 커스텀 훅이 도입되었습니다.

- **Style**
  - AI 로딩 단계의 대기 시간이 3초에서 2초로 단축되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->