### PR TITLE
Hotfix:#291 캘린더 날짜 표시 방식 변경

### DIFF
--- a/src/app/(client)/meal/_components/meal-calendar-mobile.tsx
+++ b/src/app/(client)/meal/_components/meal-calendar-mobile.tsx
@@ -5,14 +5,12 @@ import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from 
 import { useState } from 'react';
 import { Typography } from '@/components/ui/typography';
 import { formatDateToLocaleKR } from '@/utils/format.util';
-import { getKoreaTime } from '@/utils/date.util';
 
 type MealCalendarMobileProps = {
   date: Date;
   onDateChange: (date: Date) => void;
 };
-const MealCalendarMobile = ({ onDateChange }: MealCalendarMobileProps) => {
-  const [date, setDate] = useState<Date>(getKoreaTime());
+const MealCalendarMobile = ({ onDateChange, date }: MealCalendarMobileProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleSelectDate = () => {
@@ -33,7 +31,7 @@ const MealCalendarMobile = ({ onDateChange }: MealCalendarMobileProps) => {
           <Calendar
             locale={ko}
             selected={date}
-            onDayClick={setDate}
+            onDayClick={onDateChange}
             weekStartsOn={1}
             fixedWeeks
             defaultMonth={date}

--- a/src/app/(client)/meal/_components/meal-calendar-pc.tsx
+++ b/src/app/(client)/meal/_components/meal-calendar-pc.tsx
@@ -2,7 +2,6 @@
 import { Button } from '@/components/ui/button';
 import Calendar from '@/components/ui/calendar';
 import { Typography } from '@/components/ui/typography';
-import { getKoreaTime } from '@/utils/date.util';
 import { formatDateToLocaleKR } from '@/utils/format.util';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@radix-ui/react-dialog';
 import { ko } from 'date-fns/locale';
@@ -13,9 +12,8 @@ type MealCalendarPcProps = {
   onDateChange: (date: Date) => void;
 };
 
-const MealCalendarPc = ({ onDateChange }: MealCalendarPcProps) => {
+const MealCalendarPc = ({ onDateChange, date }: MealCalendarPcProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [date, setDate] = useState<Date>(getKoreaTime());
 
   const handleSelectDate = () => {
     onDateChange(date);
@@ -35,7 +33,7 @@ const MealCalendarPc = ({ onDateChange }: MealCalendarPcProps) => {
         <Calendar
           locale={ko}
           selected={date}
-          onDayClick={setDate}
+          onDayClick={onDateChange}
           weekStartsOn={1}
           defaultMonth={date}
           fixedWeeks


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #291 

<br>

## 📝 작업 내용

- 기존에 날짜를 new Date 형식으로 지정하는 방식이 아닌 props를 통해 날짜를 전달 받아 부모컴포넌트와 같은 Date를 공유




<br>

## 🖼 스크린샷
|변경 전|변경 후|
|---|---|
|![Image](https://github.com/user-attachments/assets/58d2b22b-f5c4-4404-8b1a-8b23551cf14b)|![Image](https://github.com/user-attachments/assets/cf5d0719-ecf3-42af-a87e-5befd150b686)|

<br>

## 💬 리뷰 요구사항

> 리뷰시간 `1분`
